### PR TITLE
Fix dockerfile.ocp for upstream openshift image builds

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -8,7 +8,7 @@ RUN yum update -y && \
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /tftpboot/ && \
-    cp /usr/share/ipxe/ipxe-x86_64.efi /tftpboot/ipxe.efi
+    cp /usr/share/ipxe/ipxe.efi /tftpboot/ipxe.efi
 
 COPY ./ironic.conf /tmp/ironic.conf
 RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \


### PR DESCRIPTION
Dockerfile.ocp was referring to a different file name
which is not being installed or is available to CI.

This filename was likey taken from downstream image
builds.