### PR TITLE
Add openstackclient to ocp images

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,7 +3,8 @@ FROM ubi8
 RUN yum update -y && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
-        mariadb-server python2-chardet ipxe-roms-qemu && \
+        mariadb-server python2-chardet ipxe-roms-qemu \
+        python3-ironicclient python3-ironic-inspector-client python3-openstackclient && \
     yum clean all
 
 copy ./prepare-ipxe.sh /tmp


### PR DESCRIPTION
Upstream testing is mostly done in environments where it's easy to
install openstackclient on the test/dev host, but for end-user
deployments where the provisioning host is ephemeral it will be
helpful for support/debug activities to allow running the client
inside one of the containers using this image.