### PR TITLE
Sync dockerfile from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y python-requests && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python2-chardet && \
-    yum clean all
+    yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -y python-requests && \
     yum update -y && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
-        mariadb-server python2-chardet && \
+        mariadb-server python2-chardet genisoimage && \
     yum clean all && rm -rf /var/cache/{yum,dnf}/*
 
 RUN mkdir /tftpboot && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y python-requests && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img-ev iscsi-initiator-utils parted gdisk ipxe-bootimgs psmisc sysvinit-tools \
         mariadb-server python2-chardet && \
-    yum clean all && rm -rf /var/cache/yum/*
+    yum clean all && rm -rf /var/cache/{yum,dnf}/*
 
 RUN mkdir /tftpboot && \
     cp /usr/share/ipxe/undionly.kpxe /usr/share/ipxe/ipxe.efi /tftpboot/

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,8 +3,8 @@ FROM ubi8
 RUN yum update -y && \
     yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
-        mariadb-server python2-chardet ipxe-roms-qemu && \
-    yum clean all
+        mariadb-server python2-chardet ipxe-roms-qemu genisoimage && \
+    yum clean all && rm -rf /var/cache/{yum,dnf}/*
 
 copy ./prepare-ipxe.sh /tmp
 RUN chmod +x /tmp/prepare-ipxe.sh && /tmp/prepare-ipxe.sh && rm /tmp/prepare-ipxe.sh


### PR DESCRIPTION
This pulls in the cleaning up /var/cache, and more importantly the fix that installs mkisofs so Ironic can build config drives. Otherwise with the latest BMO, you'll see a failure like this:

```
 | last_error             | Failed to prepare the configdrive. Exception: Error generating the configdrive. Make sure the "genisoimage", "mkisofs" or "xorrisofs" tool is installed. Error: [Errno 2] No such file or directory: 'xorrisofs': 'xorrisofs'
```