### PR TITLE
Enable prometheus-exporter

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,9 +1,9 @@
 FROM ubi8
 
 RUN yum update -y && \
-    yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
+    yum install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
-        mariadb-server python2-chardet ipxe-roms-qemu genisoimage && \
+        mariadb-server ipxe-roms-qemu genisoimage python3-ironic-prometheus-exporter && \
     yum clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
@@ -17,6 +17,7 @@ RUN crudini --merge /etc/ironic/ironic.conf < /tmp/ironic.conf && \
 
 COPY ./runironic-api.sh /bin/runironic-api
 COPY ./runironic-conductor.sh /bin/runironic-conductor
+COPY ./runironic-exporter.sh /bin/runironic-exporter
 COPY ./rundnsmasq.sh /bin/rundnsmasq
 COPY ./runhttpd.sh /bin/runhttpd
 COPY ./runmariadb.sh /bin/runmariadb

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -39,3 +39,4 @@ interfaces = $IRONIC_IP
 EOF
 
 mkdir -p /shared/html
+mkdir -p /shared/ironic_prometheus_exporter

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -1,6 +1,5 @@
 #!ipxe
 
-
 :retry_boot
 echo In inspector.ipxe
 imgfree

--- a/ironic.conf
+++ b/ironic.conf
@@ -21,6 +21,11 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
 automated_clean = true
+send_sensor_data = true
+# NOTE(TheJulia): Do not lower this value below 120 seconds.
+# Power state is checked every 60 seconds and BMC activity should
+# be avoided more often than once every sixty seconds.
+send_sensor_data_interval = 160
 
 [deploy]
 default_boot_option = local
@@ -30,6 +35,11 @@ http_root = /shared/html/
 
 [dhcp]
 dhcp_provider = none
+
+[oslo_messaging_notifications]
+driver = prometheus_exporter
+location = /shared/ironic_prometheus_exporter
+transport_url = fake://
 
 [pxe]
 images_path = /shared/html/tmp

--- a/runironic-exporter.sh
+++ b/runironic-exporter.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+. /bin/configure-ironic.sh
+
+FLASK_RUN_HOST=${FLASK_RUN_HOST:-"0.0.0.0"}
+FLASK_RUN_PORT=${FLASK_RUN_PORT:-"9608"}
+
+export IRONIC_CONFIG="/etc/ironic/ironic.conf"
+
+exec gunicorn -b ${FLASK_RUN_HOST}:${FLASK_RUN_PORT} -w 4 \
+    ironic_prometheus_exporter.app.wsgi:application


### PR DESCRIPTION
Adding packages installation and configuration to enable prometheus-exporter

Also removing explicit install of python-chardet, as dependency it will be installed anyway with the correct python version