### PR TITLE
add yum.conf options for smaller image

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,9 @@
 FROM ubi8
 
-RUN yum update -y && \
-    yum install -y openstack-ironic-api openstack-ironic-conductor crudini \
+RUN echo "keepcache=0" >> /etc/yum.conf && \
+    yum update -y && \
+    yum install -y --setopts=install_weak_deps=False \
+        openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
         mariadb-server python2-chardet ipxe-roms-qemu genisoimage && \
     yum clean all && \


### PR DESCRIPTION
- keepcache=0 instructs yum/dnf to not keep the cache at all
- install_weak_deps on rhel 8 ends up pulling in unnecessary X11 related bits