### PR TITLE
[WIP] Use ubi8 as base for builder

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM openshift/origin-base AS builder
+FROM ubi8 AS builder
 
 RUN if [ $(uname -m) = "x86_64" ]; then \
       yum install -y gcc git make genisoimage xz-devel grub2 grub2-efi-x64 shim dosfstools mtools && \


### PR DESCRIPTION
This is to give a kind of consistency with metal3-io, that uses
centos8 for both builder and main images, and downstream, where we
use rhel8 for builder and main images.