### PR TITLE
Bug 1796141: Temporarily disable cleaning as a workaround

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -21,7 +21,7 @@ deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
-automated_clean = true
+automated_clean = false
 bootloader = /httpboot/uefi_esp.img
 send_sensor_data = true
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
@@ -31,7 +31,7 @@ send_sensor_data_interval = 160
 
 [deploy]
 default_boot_option = local
-erase_devices_metadata_priority = 10
+erase_devices_metadata_priority = 0
 erase_devices_priority = 0
 http_root = /shared/html/
 


### PR DESCRIPTION
The HPE virtual install device presents a virutal, emulated, read-only
spinning disk which fails cleaning operations in preparation for deployment.

This device is bios controlled, and is unable to be disabled by the user.
The bios may hide it in some cases if previously disabled before the bios
version is updated, or if "intellegent provisioning" has completed on the
host as the volume is intended for installation of other operating
systems.

Some more information can be found in storyboard:

https://storyboard.openstack.org/#!/story/2007229

This patch will likely be reverted once a fix for the device handling is
available in ironic-python-agent for downstream consumption.

rhbz: #1796141