### PR TITLE
Bug 1798989: Use ubi8 based image as builder

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM openshift/origin-base AS builder
+FROM ironic-builder AS builder
 
 RUN if [ $(uname -m) = "x86_64" ]; then \
       yum install -y gcc git make genisoimage xz-devel grub2 grub2-efi-x64 shim dosfstools mtools && \


### PR DESCRIPTION
We build an image during the build process and use it as builder.

This patch depends on https://github.com/openshift/release/pull/7010