### PR TITLE
Bug 1807633: Copy snpnoly.efi to tftpboot directory

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -23,6 +23,9 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 
+COPY ./prepare-ipxe.sh /tmp
+RUN chmod +x /tmp/prepare-ipxe.sh && /tmp/prepare-ipxe.sh && rm /tmp/prepare-ipxe.sh
+
 COPY --from=builder /tmp/esp.img /httpboot/uefi_esp.img
 
 COPY ./ironic.conf /tmp/ironic.conf

--- a/prepare-ipxe.sh
+++ b/prepare-ipxe.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# prepare-ipxe copies the right images to /tftpboot, later when the
+# shared volume is created, rundnsmasq will copy them there to
+# /shared/tftpboot. We do this as a two-step operation to ensure all
+# the expected images are available at build-time. Otherwise the CI
+# jobs that build these images could succeed, but provisioning
+# will actually fail without the images present.
+
+set -ex
+
+mkdir -p /tftpboot
+
+cp /usr/share/ipxe/undionly.kpxe /tftpboot/
+cp /usr/share/ipxe/ipxe-snponly-x86_64.efi /tftpboot/snponly.efi
+
+if [ -f "/usr/share/ipxe/ipxe.efi" ]; then
+    cp /usr/share/ipxe/ipxe.efi /tftpboot/ipxe.efi
+elif [ -f "/usr/share/ipxe/ipxe-x86_64.efi" ]; then
+    cp  /usr/share/ipxe/ipxe-x86_64.efi /tftpboot/ipxe.efi
+else
+    echo "Fatal Error - Failed to find ipxe binary"
+    exit 1
+fi

--- a/rundnsmasq.sh
+++ b/rundnsmasq.sh
@@ -13,16 +13,7 @@ mkdir -p /shared/html/pxelinux.cfg
 mkdir -p /shared/log/dnsmasq
 
 # Copy files to shared mount
-# TODO(stbenjam): Add snponly.efi to this list when it's available from EL8 packages.
-cp /usr/share/ipxe/undionly.kpxe /shared/tftpboot
-if [ -f "/usr/share/ipxe/ipxe.efi" ]; then
-    cp /usr/share/ipxe/ipxe.efi /shared/tftpboot/ipxe.efi
-elif [ -f "/usr/share/ipxe/ipxe-x86_64.efi" ]; then
-    cp  /usr/share/ipxe/ipxe-x86_64.efi /shared/tftpboot/ipxe.efi
-else
-    echo "Fatal Error - Failed to find ipxe binary"
-    exit 1
-fi
+cp /tftpboot/* /shared/tftpboot/
 
 # Template and write dnsmasq.conf
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf


### PR DESCRIPTION
This is required for doing UEFI + IPv6 provisioning. It requires updated
iPXE packages.

--
Note: To be cherry-picked to 4.4 and 4.3.z, but will need to be done manually as it should include https://github.com/openshift/ironic-image/pull/43 as well.

4.4 BZ: 1807634 
4.3 BZ: 1807635

