### PR TITLE
Bug 1809658: Add schema to bootloader setting

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -22,7 +22,7 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 
 [conductor]
 automated_clean = false
-bootloader = /httpboot/uefi_esp.img
+bootloader = file:///httpboot/uefi_esp.img
 send_sensor_data = true
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
 # Power state is checked every 60 seconds and BMC activity should


### PR DESCRIPTION
It is currently pointing to a local file, but without
a file:// schema, so it is failing validation on
ironic.

Signed-off-by: Yolanda Robla yroblamo@redhat.com