### PR TITLE
Do not upgrade systemd package

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -15,7 +15,7 @@ RUN if [ $(uname -m) = "x86_64" ]; then \
 
 FROM ubi8
 
-RUN dnf update -y && \
+RUN dnf upgrade -y  --exclude=systemd && \
     dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
         iproute iptables dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
         mariadb-server ipxe-roms-qemu genisoimage python3-ironic-prometheus-exporter \


### PR DESCRIPTION
The systemd package has been marked as protected and it's causing
issues when we upgrade the image.
Running dnf with the --exclude option should prevent this to
block the image build process.
Also using the correct upgrade command.