### PR TITLE
Whitespace change to trigger a new image build

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -52,3 +52,4 @@ COPY ./inspector.ipxe /tmp/inspector.ipxe
 COPY ./dualboot.ipxe /tmp/dualboot.ipxe
 
 ENTRYPOINT ["/bin/runironic"]
+


### PR DESCRIPTION
We recently tagged a new version of python3-openstacksdk to fix a bug,
but need a new image built to pull in the package.