### PR TITLE
Bug 1814901: Disable default gateway for provisioning network in IPv6

### DIFF
--- a/dnsmasq.conf.j2
+++ b/dnsmasq.conf.j2
@@ -34,7 +34,7 @@ dhcp-boot=/undionly.kpxe,{{ env["IRONIC_IP"] }}
 {% if env["IPV"] == "6" %}
 # IPv6 Configuration:
 enable-ra
-ra-param={{ env["PROVISIONING_INTERFACE"] }},10
+ra-param={{ env["PROVISIONING_INTERFACE"] }},0,0
 
 dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
 dhcp-userclass=set:ipxe6,iPXE


### PR DESCRIPTION
Currently the provisioning network DHCPv6 configuration ends up setting
a default route on hosts to be the metal3 pod itself.

This mailing list post[1] describes the problem in detail. We need to
set the ra-params for interval=0 and lifetime=0.

Cherry-pick of https://github.com/metal3-io/ironic-image/pull/145

[1] https://www.redhat.com/archives/libvir-list/2016-June/msg02203.html