### PR TITLE
Bug 1822763: Increase command retries and add PXE booting retries

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -19,10 +19,17 @@ use_stderr = true
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy
+# NOTE(dtantsur): in some environments temporary networking issues can cause
+# the whole deployment to fail on inability to reach the ramdisk. Increasing
+# retries here works around such problems without affecting the normal path.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1822763
+max_command_attempts = 30
 
 [conductor]
 automated_clean = false
 bootloader = file:///httpboot/uefi_esp.img
+# NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
+deploy_callback_timeout = 4800
 send_sensor_data = true
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
 # Power state is checked every 60 seconds and BMC activity should
@@ -44,6 +51,10 @@ location = /shared/ironic_prometheus_exporter
 transport_url = fake://
 
 [pxe]
+# NOTE(dtantsur): keep this value at least 3x lower than
+# [conductor]deploy_callback_timeout so that at least some retries happen.
+# The default settings enable 3 retries after 20 minutes each.
+boot_retry_timeout = 1200
 images_path = /shared/html/tmp
 instance_master_path = /shared/html/master_images
 ipxe_enabled = true


### PR DESCRIPTION
When operating in an environment with networking issues, these two
seem to be the biggest sources of deployment/cleaning failures:
1) Substantially increase the number of retries for the ramdisk commands.
2) Enable PXE boot retries after 20 minutes of not hearing from the ramdisk.

See https://bugzilla.redhat.com/show_bug.cgi?id=1822763