### PR TITLE
Disable sensor data collection

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -30,7 +30,7 @@ automated_clean = false
 bootloader = file:///httpboot/uefi_esp.img
 # NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
 deploy_callback_timeout = 4800
-send_sensor_data = true
+send_sensor_data = false
 # NOTE(TheJulia): Do not lower this value below 120 seconds.
 # Power state is checked every 60 seconds and BMC activity should
 # be avoided more often than once every sixty seconds.


### PR DESCRIPTION
Sensor data collection was intended for an earlier use of
the ironic-image and resulting ironic container image in order
to supply data to prometheus about hardware that has not yet
been deployed upon. Since the deicsion was made not to leverage
the data, it seems pointless to collect sensor data.

As such, disable sensor data collection.