### PR TITLE
Bug 1847317: Add WORKDIR to builder

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,6 @@
-FROM openshift/origin-base AS builder
+FROM ironic-builder AS builder
+
+WORKDIR /tmp
 
 RUN if [ $(uname -m) = "x86_64" ]; then \
       yum install -y gcc git make genisoimage xz-devel grub2 grub2-efi-x64 shim dosfstools mtools && \


### PR DESCRIPTION
This should fix the issues we're seeing sometimes where the
esp.img can't be copied to the final image.

(cherry picked from commit e263a5c90685f83217543519bbd17af248284613)

Plus change builder to ironic-builder to fix wrong base image.