### PR TITLE
Update inspection configuration to enable fast-track

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -34,6 +34,10 @@ fast_track = ${IRONIC_FAST_TRACK}
 
 [inspector]
 endpoint_override = http://${IRONIC_URL_HOST}:5050
+# TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
+# not, so working around here.
+# NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
+extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ipa-api-url=http://${IRONIC_URL_HOST}:6385
 
 [mdns]
 interfaces = $IRONIC_IP

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -12,6 +12,16 @@ IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
 
 wait_for_interface_or_ip
 
+if [[ $IRONIC_FAST_TRACK == true ]]; then
+    INSPECTOR_POWER_OFF=false
+    # TODO(dtantsur): ipa-api-url should be populated by ironic itself, but
+    # it's not yet, so working around here.
+    INSPECTOR_EXTRA_ARGS=" ipa-api-url=http://${IRONIC_URL_HOST}:6385"
+else
+    INSPECTOR_POWER_OFF=true
+    INSPECTOR_EXTRA_ARGS=""
+fi
+
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 
 crudini --merge /etc/ironic/ironic.conf <<EOF
@@ -34,10 +44,9 @@ fast_track = ${IRONIC_FAST_TRACK}
 
 [inspector]
 endpoint_override = http://${IRONIC_URL_HOST}:5050
-# TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
-# not, so working around here.
+power_off = ${INSPECTOR_POWER_OFF}
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ipa-api-url=http://${IRONIC_URL_HOST}:6385
+extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 ${INSPECTOR_EXTRA_ARGS}
 
 [mdns]
 interfaces = $IRONIC_IP

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -3,6 +3,8 @@
 :retry_boot
 echo In inspector.ipxe
 imgfree
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+# NOTE(dtantsur): keep inspection kernel params in [mdns]params in
+# ironic-inspector-image and configuration in configure-ironic.sh
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-api-url=http://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/inspector.ipxe
+++ b/inspector.ipxe
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-api-url=http://IRONIC_IP:6385 ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+kernel --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://IRONIC_IP:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 EXTRA_ARGS initrd=ironic-python-agent.initramfs || goto retry_boot
 initrd --timeout 60000 http://IRONIC_IP:HTTP_PORT/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic.conf
+++ b/ironic.conf
@@ -45,9 +45,6 @@ http_root = /shared/html/
 [dhcp]
 dhcp_provider = none
 
-[inspector]
-power_off = false
-
 [oslo_messaging_notifications]
 driver = prometheus_exporter
 location = /shared/ironic_prometheus_exporter

--- a/ironic.conf
+++ b/ironic.conf
@@ -45,6 +45,9 @@ http_root = /shared/html/
 [dhcp]
 dhcp_provider = none
 
+[inspector]
+power_off = false
+
 [oslo_messaging_notifications]
 driver = prometheus_exporter
 location = /shared/ironic_prometheus_exporter

--- a/runhttpd.sh
+++ b/runhttpd.sh
@@ -4,17 +4,29 @@
 
 HTTP_PORT=${HTTP_PORT:-"80"}
 
+# Whether to enable fast_track provisioning or not
+IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
+
 wait_for_interface_or_ip
 
 mkdir -p /shared/html
 chmod 0777 /shared/html
+
+if [[ $IRONIC_FAST_TRACK == true ]]; then
+    INSPECTOR_EXTRA_ARGS="ipa-api-url=http://${IRONIC_URL_HOST}:6385"
+else
+    INSPECTOR_EXTRA_ARGS=""
+fi
 
 # Copy files to shared mount
 cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
 cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
 
 # Use configured values
-sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g -e s/HTTP_PORT/${HTTP_PORT}/g /shared/html/inspector.ipxe
+sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g \
+    -e s/HTTP_PORT/${HTTP_PORT}/g \
+    -e "s|EXTRA_ARGS|${INSPECTOR_EXTRA_ARGS}|g" \
+    /shared/html/inspector.ipxe
 
 sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
 sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \


### PR DESCRIPTION
Add ipa-api-url to inspector.ipxe and extra params in ironic.conf.
Without it ironic will never learn that the ramdisk has been booted
for inspection, requiring a reboot despite fast-track enabled.
    
NOTE: we need to configure everything in two places because there are
two inspection paths: discovery-style (via inspector.ipxe) and managed
(the same way as cleaning and deployment work).
    
Backport of https://github.com/metal3-io/ironic-image/pull/163 and https://github.com/metal3-io/ironic-image/pull/173
