### PR TITLE
Change endpoint URL recording for ironic 15.x

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -33,7 +33,6 @@ host_ip = ::
 api_workers = $NUMWORKERS
 
 [conductor]
-api_url = http://${IRONIC_URL_HOST}:6385
 
 [database]
 connection = mysql+pymysql://ironic:${MARIADB_PASSWORD}@localhost/ironic?charset=utf8
@@ -50,6 +49,9 @@ extra_kernel_params = ipa-inspector-collectors=default,extra-hardware,logs ipa-i
 
 [mdns]
 interfaces = $IRONIC_IP
+
+[service_catalog]
+endpoint_override = http://${IRONIC_URL_HOST}:6385
 EOF
 
 mkdir -p /shared/html


### PR DESCRIPTION
Ironic 15.x removes a long deprecated [conductor]api_url
parameter. This patch prepares for that by setting the correct
parameter, and notes in-line the old parameter that can be
eventually removed once OpenShift begins consuming ironic 15.x.