### PR TITLE
Skip weak dependencies and install driver libraries explicitly

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -22,10 +22,12 @@ RUN if [ $(uname -m) = "x86_64" ]; then \
 FROM ubi8
 
 RUN dnf update -y && \
-    dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
-        iproute dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
-        mariadb-server ipxe-roms-qemu genisoimage python3-ironic-prometheus-exporter \
-        python3-jinja2 python3-sushy-oem-idrac && \
+    dnf --setopt=install_weak_deps=False install -y python3-gunicorn \
+        openstack-ironic-api openstack-ironic-conductor crudini \
+        iproute dnsmasq httpd qemu-img iscsi-initiator-utils parted gdisk psmisc \
+        mariadb-server genisoimage python3-ironic-prometheus-exporter \
+        python3-jinja2 python3-sushy-oem-idrac ipmitool python3-dracclient \
+        python3-scciclient python3-sushy && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 

--- a/ironic.conf
+++ b/ironic.conf
@@ -7,6 +7,8 @@ default_inspect_interface = inspector
 default_network_interface = noop
 enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
 enabled_deploy_interfaces = direct,fake
+# NOTE(dtantsur): when changing this, make sure to update the driver
+# dependencies in Dockerfile.
 enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish
 enabled_inspect_interfaces = inspector,idrac,irmc,fake,redfish
 enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish


### PR DESCRIPTION
Driver dependencies are now weak dependencies in RDO. Skip weak
dependencies and only install the ones we need explicitly.