### PR TITLE
Set the hash ring algorithm to SHA256

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -17,6 +17,8 @@ enabled_raid_interfaces = no-raid,irmc,agent,fake
 enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
 rpc_transport = json-rpc
 use_stderr = true
+# NOTE(dtantsur): the default md5 is not compatible with FIPS mode
+hash_ring_algorithm = sha256
 
 [agent]
 deploy_logs_collect = always


### PR DESCRIPTION
The default MD5 is not compatible with FIPS mode. See
https://bugzilla.redhat.com/show_bug.cgi?id=1853302

Upstream: https://github.com/metal3-io/ironic-image/pull/179