### PR TITLE
Add HTTP Basic Auth support

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -5,6 +5,8 @@
 USE_HTTP_BASIC=${USE_HTTP_BASIC:-false}
 IRONIC_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
 IRONIC_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
+INSPECTOR_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
+INSPECTOR_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
 
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
@@ -65,6 +67,10 @@ if [ "$USE_HTTP_BASIC" = "true" ]; then
 
 	crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy http_basic
 	crudini --set /etc/ironic/ironic.conf DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic
+
+	crudini --set /etc/ironic/ironic.conf inspector auth_type http_basic
+	crudini --set /etc/ironic/ironic.conf inspector username $INSPECTOR_HTTP_BASIC_USERNAME
+	crudini --set /etc/ironic/ironic.conf inspector password $INSPECTOR_HTTP_BASIC_PASSWORD
 
 	crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy http_basic
 	crudini --del /etc/ironic/ironic.conf json_rpc host_ip

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -2,12 +2,6 @@
 
 . /bin/ironic-common.sh
 
-USE_HTTP_BASIC=${USE_HTTP_BASIC:-false}
-IRONIC_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
-IRONIC_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
-INSPECTOR_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
-INSPECTOR_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
-
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
@@ -63,21 +57,31 @@ EOF
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter
 
-if [ "$USE_HTTP_BASIC" = "true" ]; then
-
-	crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy http_basic
-	crudini --set /etc/ironic/ironic.conf DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic
-
-	crudini --set /etc/ironic/ironic.conf inspector auth_type http_basic
-	crudini --set /etc/ironic/ironic.conf inspector username $INSPECTOR_HTTP_BASIC_USERNAME
-	crudini --set /etc/ironic/ironic.conf inspector password $INSPECTOR_HTTP_BASIC_PASSWORD
-
-	crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy http_basic
-	crudini --del /etc/ironic/ironic.conf json_rpc host_ip
-	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_auth_user_file /shared/htpasswd-ironic
-	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_username $IRONIC_HTTP_BASIC_USERNAME
-	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_password $IRONIC_HTTP_BASIC_PASSWORD
-
-	## NOTE(iurygregory): reusing the ironic credentials so we don't end up with wrong client credentials
-	htpasswd -nbB $IRONIC_HTTP_BASIC_USERNAME $IRONIC_HTTP_BASIC_PASSWORD > /shared/htpasswd-ironic
+HTPASSWD_FILE=/etc/ironic/htpasswd
+if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
+    printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
 fi
+set_http_basic_server_auth_strategy() {
+    local section=${1:-DEFAULT}
+    crudini --set /etc/ironic/ironic.conf ${section} auth_strategy http_basic
+    crudini --set /etc/ironic/ironic.conf ${section} http_basic_auth_user_file "${HTPASSWD_FILE}"
+}
+
+# Configure HTTP basic auth for ironic-api server
+if [ -f "${HTPASSWD_FILE}" ]; then
+    set_http_basic_server_auth_strategy
+fi
+
+
+# Configure auth for clients
+IRONIC_API_CONFIG_OPTIONS="--config-file /usr/share/ironic/ironic-dist.conf --config-file /etc/ironic/ironic.conf"
+
+configure_client_basic_auth() {
+    local auth_config_file="/auth/$1/auth-config"
+    if [ -f ${auth_config_file} ]; then
+        IRONIC_API_CONFIG_OPTIONS+=" --config_file ${auth_config_file}"
+    fi
+}
+
+configure_client_basic_auth ironic-inspector
+configure_client_basic_auth ironic-rpc

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -2,6 +2,10 @@
 
 . /bin/ironic-common.sh
 
+USE_HTTP_BASIC=${USE_HTTP_BASIC:-false}
+IRONIC_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
+IRONIC_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
+
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
@@ -56,3 +60,16 @@ EOF
 
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter
+
+if [ "$USE_HTTP_BASIC" = "true" ]; then
+
+	crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy http_basic
+	crudini --set /etc/ironic/ironic.conf DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic
+	crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy http_basic
+	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_auth_user_file /shared/htpasswd-ironic
+	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_username $IRONIC_HTTP_BASIC_USERNAME
+	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_password $IRONIC_HTTP_BASIC_PASSWORD
+
+	## NOTE(iurygregory): reusing the ironic credentials so we don't end up with wrong client credentials
+	htpasswd -nbB $IRONIC_HTTP_BASIC_USERNAME $IRONIC_HTTP_BASIC_PASSWORD > /shared/htpasswd-ironic
+fi

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -65,7 +65,9 @@ if [ "$USE_HTTP_BASIC" = "true" ]; then
 
 	crudini --set /etc/ironic/ironic.conf DEFAULT auth_strategy http_basic
 	crudini --set /etc/ironic/ironic.conf DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic
+
 	crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy http_basic
+	crudini --del /etc/ironic/ironic.conf json_rpc host_ip
 	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_auth_user_file /shared/htpasswd-ironic
 	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_username $IRONIC_HTTP_BASIC_USERNAME
 	crudini --set /etc/ironic/ironic.conf json_rpc http_basic_password $IRONIC_HTTP_BASIC_PASSWORD

--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -79,7 +79,7 @@ IRONIC_API_CONFIG_OPTIONS="--config-file /usr/share/ironic/ironic-dist.conf --co
 configure_client_basic_auth() {
     local auth_config_file="/auth/$1/auth-config"
     if [ -f ${auth_config_file} ]; then
-        IRONIC_API_CONFIG_OPTIONS+=" --config_file ${auth_config_file}"
+        IRONIC_API_CONFIG_OPTIONS+=" --config-file ${auth_config_file}"
     fi
 }
 

--- a/ironic.conf
+++ b/ironic.conf
@@ -40,6 +40,10 @@ send_sensor_data = false
 # be avoided more often than once every sixty seconds.
 send_sensor_data_interval = 160
 
+[json_rpc]
+auth_strategy = noauth
+host_ip = localhost
+
 [deploy]
 default_boot_option = local
 erase_devices_metadata_priority = 0

--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,4 +2,4 @@
 
 . /bin/configure-ironic.sh
 
-exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf
+exec /usr/bin/ironic-api ${IRONIC_API_CONFIG_OPTIONS}

--- a/runironic-conductor.sh
+++ b/runironic-conductor.sh
@@ -5,6 +5,12 @@
 # Ramdisk logs
 mkdir -p /shared/log/ironic/deploy
 
+# If the config file has the json-rpc server bound to a specific address
+# (rather than the default ::), use that address as the host name
+if bind_addr="$(crudini --get /etc/ironic/ironic.conf json_rpc host_ip 2>/dev/null)"; then
+  crudini --set /etc/ironic/ironic.conf DEFAULT host ${bind_addr}
+fi
+
 # It's possible for the dbsync to fail if mariadb is not up yet, so
 # retry until success
 until ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade; do

--- a/runironic.sh
+++ b/runironic.sh
@@ -12,7 +12,7 @@ rm -rf /shared/log/ironic
 mkdir -p /shared/log/ironic
 
 /usr/bin/ironic-conductor &
-/usr/bin/ironic-api &
+/usr/bin/ironic-api ${IRONIC_API_CONFIG_OPTIONS} &
 
 sleep infinity
 

--- a/runironic.sh
+++ b/runironic.sh
@@ -2,6 +2,8 @@
 
 . /bin/configure-ironic.sh
 
+crudini --set /etc/ironic/ironic.conf DEFAULT host localhost
+
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
 
 # Remove log files from last deployment


### PR DESCRIPTION
* Expect all server credentials to be passed in the form of an `HTTP_BASIC_HTPASSWD` environment variable containing both the username and the *hash* of the password, in the htpasswd format.
 
* Expect client credentials to be passed in the form of a file named `/auth/ironic-inspector/auth-config` (for ironic-inspector) or `/auth/ironic-rpc/auth-config` (for the json-rpc interface to ironic-conductor), formatted as an ini config file setting the appropriate options (for basic auth, this is auth_strategy=http_basic, and the username and password options; however this mechanism should work unchanged for other auth strategies).
