### PR TITLE
Add argument for base image

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,5 @@
-FROM ironic-builder AS builder
+ARG BaseImage=ironic-builder
+FROM $BaseImage AS builder
 
 WORKDIR /tmp
 
@@ -19,7 +20,7 @@ RUN if [ $(uname -m) = "x86_64" ]; then \
       touch /tmp/esp.img; \
     fi
 
-FROM ubi8
+FROM $BaseImage
 
 RUN dnf update -y && \
     dnf --setopt=install_weak_deps=False install -y python3-gunicorn \


### PR DESCRIPTION
This change adds an ARG BaseImage to the Dockerfile giving the
possibility to change the base image during build without
editing the Dockerfile.
This can be particularly useful for testing and in development
environments.