### PR TITLE
bug 1859334: Remove all unused modules

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -58,5 +58,10 @@ COPY ./dnsmasq.conf.j2 /etc/dnsmasq.conf.j2
 COPY ./inspector.ipxe /tmp/inspector.ipxe
 COPY ./dualboot.ipxe /tmp/dualboot.ipxe
 
+# Custom httpd config, removes all but the bare minimum needed modules
+RUN rm -f /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf
+COPY ./httpd.conf /etc/httpd/conf.d/httpd.conf
+COPY ./httpd-modules.conf /etc/httpd/conf.modules.d/httpd-modules.conf
+
 ENTRYPOINT ["/bin/runironic"]
 

--- a/httpd-modules.conf
+++ b/httpd-modules.conf
@@ -1,0 +1,7 @@
+# Bare minimum set of modules
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule mpm_event_module modules/mod_mpm_event.so

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,0 +1,8 @@
+
+# http TRACE can be subjected to abuse and should be disabled
+TraceEnable off
+
+# provide minimal server information
+ServerTokens Prod
+ServerSignature Off
+


### PR DESCRIPTION
Leave httpd with the minimum needed for metal3,
in particular we wanted to disable directory listing and
http TRACE. But disabling everything we don't use seems
prudent.