### PR TITLE
Bug 1862608: Install and configure for syslinux-nonlinux

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -20,6 +20,8 @@ use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
 
+isolinux_bin = /usr/share/syslinux/isolinux.bin
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -21,3 +21,4 @@ python3-scciclient
 python3-sushy
 python3-sushy-oem-idrac
 qemu-img
+syslinux-nonlinux


### PR DESCRIPTION
ironic needs syslinux-nonlinux to generate a
bootable ISO image for virtmedia install on bios.

(cherry picked from commit a20cb04c80b784cf0b417229df1ec5b4880cb5ec)