### PR TITLE
Bug 1884155: Explicitly set json_rpc.auth_strategy to noauth

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -70,6 +70,9 @@ set_http_basic_server_auth_strategy() {
 # Configure HTTP basic auth for ironic-api server
 if [ -f "${HTPASSWD_FILE}" ]; then
     set_http_basic_server_auth_strategy
+    # We've just set the DEFAULT auth_strategy to http_basic, we need to
+    # set the json_rpc auth_strategy back to noauth
+    crudini --set /etc/ironic/ironic.conf json_rpc auth_strategy noauth
 fi
 
 

--- a/ironic.conf
+++ b/ironic.conf
@@ -41,7 +41,9 @@ send_sensor_data = false
 send_sensor_data_interval = 160
 
 [json_rpc]
-auth_strategy = noauth
+# crudini doesn't merge this into ironic.conf as it sees it as redundant (its set globably in DEFAULT)
+# so we set it in configure-ironic.sh if we change the DEFAULT
+# auth_strategy = noauth
 host_ip = localhost
 
 [deploy]


### PR DESCRIPTION
Using crudini to merge this into ironic.conf no longer
works as it gets ignored as it matches the DEFAULT and
it is redundant. But later we then change the DEFAULT in
set_http_basic_server_auth_strategy so we need to set
json_rpc.auth_strategy back to noauth.

Downstream only patch to fix openshift-metal3/dev-scripts#1099 , this problem was fixed upstream during a switch to jinja2 for ironic.conf but a simpler patch is preferred in openshift so close to code freeze.

