### PR TITLE
Revert "Bug 1862608: Install and configure for syslinux-nonlinux"

### DIFF
--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -35,8 +35,6 @@ host = localhost
 host = {{ env.IRONIC_IP }}
 {% endif %}
 
-isolinux_bin = /usr/share/syslinux/isolinux.bin
-
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -22,4 +22,3 @@ python3-scciclient
 python3-sushy
 python3-sushy-oem-idrac
 qemu-img
-syslinux-nonlinux


### PR DESCRIPTION
Reverts openshift/ironic-image#106
Unfortunately there is no syslinux-nonlinux package for ppc64le and this is causing mayhem during the build process for that architecture