### PR TITLE
Bug 1862608: Install syslinux-nonlinux

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -27,6 +27,9 @@ COPY ${PKGS_LIST} /tmp/main-packages-list.txt
 
 RUN dnf upgrade -y && \
     dnf --setopt=install_weak_deps=False install -y $(cat /tmp/main-packages-list.txt) && \
+    if [ $(uname -m) = "x86_64" ]; then \
+      dnf install -y syslinux-nonlinux; \
+    fi && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -35,6 +35,8 @@ host = localhost
 host = {{ env.IRONIC_IP }}
 {% endif %}
 
+isolinux_bin = /usr/share/syslinux/isolinux.bin
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
The syslinux-nonlinux package is needed to generate a
bootable ISO image for virtmedia install on bios.
The package is available for x86_64 arch only, so we need a
conditional statement in the Dockerfile.