### PR TITLE
DNM: Just testing

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -2,18 +2,15 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift AS builder
 
 WORKDIR /tmp
 
-## NOTE(derekh): We need to build our own grub image because the one
-## that gets installed by grub2-efi-x64 (/boot/efi/EFI/centos/grubx64.efi)
-## looks for grub.cnf in /EFI/centos, ironic puts it in /boot/grub
 RUN if [ $(uname -m) = "x86_64" ]; then \
-      dnf install -y gcc git make genisoimage xz-devel grub2 grub2-efi-x64-modules shim dosfstools mtools && \
+      dnf install -y gcc git make genisoimage xz-devel grub2 grub2-efi-x64 shim dosfstools mtools && \
       dd bs=1024 count=3200 if=/dev/zero of=esp.img && \
       mkfs.msdos -F 12 -n 'ESP_IMAGE' ./esp.img && \
       mmd -i esp.img EFI && \
       mmd -i esp.img EFI/BOOT && \
-      grub2-mkimage -C xz -O x86_64-efi -p /boot/grub -o /tmp/grubx64.efi boot linux search normal configfile part_gpt btrfs ext2 fat iso9660 loopback test keystatus gfxmenu regexp probe efi_gop efi_uga all_video gfxterm font scsi echo read ls cat png jpeg halt reboot && \
+      mmd -i esp.img EFI/redhat && \
       mcopy -i esp.img -v /boot/efi/EFI/BOOT/BOOTX64.EFI ::EFI/BOOT && \
-      mcopy -i esp.img -v /tmp/grubx64.efi ::EFI/BOOT && \
+      mcopy -i esp.img -v /boot/efi/EFI/redhat/grubx64.efi ::EFI/redhat && \
       mdir -i esp.img ::EFI/BOOT; \
     else \
       touch /tmp/esp.img; \

--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -37,6 +37,10 @@ host = {{ env.IRONIC_URL_HOST }}
 
 isolinux_bin = /usr/share/syslinux/isolinux.bin
 
+# NOTE(dtantsur): this path is specific to the GRUB image that is built into
+# the ESP provided in [conductor]bootloader.
+grub_config_path = EFI/redhat/grub.cfg
+
 [agent]
 deploy_logs_collect = always
 deploy_logs_local_path = /shared/log/ironic/deploy


### PR DESCRIPTION
Avoid rebuilding GRUB2 since it invalidates its signature. Ironic
is able to build correct ISO images if you provide it with
a distribution specific EFI config path.

See https://review.opendev.org/760434

Upstream: https://github.com/metal3-io/ironic-image/pull/212