### PR TITLE
Bug 1899107: Limit the default number of API workers to 4

### DIFF
--- a/configure-ironic.sh
+++ b/configure-ironic.sh
@@ -4,8 +4,11 @@
 
 HTTP_PORT=${HTTP_PORT:-"80"}
 MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
+# TODO(dtantsur): remove the explicit default once we get
+# https://review.opendev.org/761185 in the repositories
 NUMPROC=$(cat /proc/cpuinfo  | grep "^processor" | wc -l)
-NUMWORKERS=$(( NUMPROC < 12 ? NUMPROC : 12 ))
+NUMPROC=$(( NUMPROC <= 4 ? NUMPROC : 4 ))
+export NUMWORKERS=${NUMWORKERS:-$NUMPROC}
 
 # Whether to enable fast_track provisioning or not
 IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}


### PR DESCRIPTION
12 is a lot of workers. With up to 100MiB of RAM per each, ironic-api
processes may occupy more than 1GiB of RAM in such configuration.

Since even CERN uses 2 workers in their configuration, we should
be fine with no more than 4. A similar change is made upstream:
https://review.opendev.org/761185