### PR TITLE
Add additional drivers to enabled BIOS interface

### DIFF
--- a/ironic.conf.j2
+++ b/ironic.conf.j2
@@ -10,7 +10,7 @@ default_boot_interface = ipxe
 default_deploy_interface = direct
 default_inspect_interface = inspector
 default_network_interface = noop
-enabled_bios_interfaces = idrac-wsman,no-bios
+enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish,irmc
 enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
 enabled_deploy_interfaces = direct,fake
 # NOTE(dtantsur): when changing this, make sure to update the driver


### PR DESCRIPTION
Add Redfish as a BIOS interface to allow retrieving BIOS configuration
using Redfish.