### PR TITLE
Move upgrade and install logic to a script

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -20,14 +20,10 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 ARG PKGS_LIST=main-packages-list.txt
 
 COPY ${PKGS_LIST} /tmp/main-packages-list.txt
+COPY prepare-image.sh /bin/
 
-RUN dnf upgrade -y && \
-    dnf --setopt=install_weak_deps=False install -y $(cat /tmp/main-packages-list.txt) && \
-    if [ $(uname -m) = "x86_64" ]; then \
-      dnf install -y syslinux-nonlinux; \
-    fi && \
-    dnf clean all && \
-    rm -rf /var/cache/{yum,dnf}/*
+RUN prepare-image.sh && \
+  rm -f /bin/prepare-image.sh
 
 COPY ./prepare-ipxe.sh /tmp
 RUN chmod +x /tmp/prepare-ipxe.sh && /tmp/prepare-ipxe.sh && rm /tmp/prepare-ipxe.sh

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+set -ex
+
+dnf upgrade -y
+dnf --setopt=install_weak_deps=False install -y $(cat /tmp/main-packages-list.txt)
+if [ $(uname -m) = "x86_64" ]; then
+    dnf install -y syslinux-nonlinux;
+fi
+dnf clean all
+rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
In the effort of cleaning the Dockerfile, we move the upgrade and
install logic to a script.

(cherry picked from commit 181746690865148f050e4f28889b63e87975e849)