### PR TITLE
Bug 1903649: Re-enable automated_clean

### DIFF
--- a/ironic.conf
+++ b/ironic.conf
@@ -30,7 +30,7 @@ deploy_logs_local_path = /shared/log/ironic/deploy
 max_command_attempts = 30
 
 [conductor]
-automated_clean = false
+automated_clean = true
 bootloader = file:///httpboot/uefi_esp.img
 # NOTE(dtantsur): keep aligned with [pxe]boot_retry_timeout below.
 deploy_callback_timeout = 4800
@@ -48,7 +48,7 @@ host_ip = localhost
 
 [deploy]
 default_boot_option = local
-erase_devices_metadata_priority = 0
+erase_devices_metadata_priority = 10
 erase_devices_priority = 0
 http_root = /shared/html/
 


### PR DESCRIPTION
This was disabled to avoid an ironic bug that is now fixed, in
short ironic now Skips read-only devices when cleaning.

see
https://storyboard.openstack.org/#!/story/2007229