### PR TITLE
Bug 1906806: Introduce separate ARG for extra packages list

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -17,9 +17,10 @@ RUN if [ $(uname -m) = "x86_64" ]; then \
 
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 
-ARG PKGS_LIST=main-packages-list.txt
+ENV PKGS_LIST=main-packages-list.txt
+ARG EXTRA_PKGS_LIST
 
-COPY ${PKGS_LIST} /tmp/main-packages-list.txt
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST} /tmp/
 COPY prepare-image.sh /bin/
 
 RUN prepare-image.sh && \

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -3,9 +3,14 @@
 set -ex
 
 dnf upgrade -y
-dnf --setopt=install_weak_deps=False install -y $(cat /tmp/main-packages-list.txt)
+dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${PKGS_LIST})
 if [ $(uname -m) = "x86_64" ]; then
     dnf install -y syslinux-nonlinux;
+fi
+if [[ ! -z ${EXTRA_PKGS_LIST} ]]; then
+    if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
+        dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${EXTRA_PKGS_LIST})
+    fi
 fi
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
Convert the current PKGS_LIST to ENV as we should not really touch it.
Introduce the EXTRA_PKGS_LIST ARG to allow specifying a file
containing a list of extra packages to install.
The goal is to allow installing packages from different sources
to test them.

(cherry picked from commit a411a5aa6e9571e4095d52cc0d7e73ada6c2a9c7)