### PR TITLE
Bug 1916145: Explicitly set minimum versions of python libraries

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -10,15 +10,32 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api
-openstack-ironic-conductor
+openstack-ironic-api >= 16.0.3-0.20201219231205.4ae5375.el8
+openstack-ironic-conductor >= 16.0.3-0.20201219231205.4ae5375.el8
 parted
 psmisc
+python3-debtcollector >= 2.2.0-0.20201008171245.649189d.el8
 python3-dracclient
 python3-gunicorn
+python3-ironic-lib >= 4.4.1-0.20201218041209.aa7cfec.el8
 python3-ironic-prometheus-exporter
 python3-jinja2
+python3-msgpack >= 0.6.2-1.el8ost
+python3-oslo-concurrency >= 4.3.0-0.20201008180343.2f78803.el8
+python3-oslo-config >= 8.3.2-0.20201008180634.fcb8894.el8
+python3-oslo-context >= 3.1.1-0.20201008190523.57dbded.el8
+python3-oslo-i18n >= 5.0.1-0.20201009131251.73187bd.el8
+python3-oslo-log >= 4.3.1-0.20201207021200.1597f24.el8
+python3-oslo-serialization >= 4.0.1-0.20201008182423.c7884b2.el8
+python3-oslo-service >= 2.4.0-0.20201008184547.58466a6.el8
+python3-oslo-utils >= 4.6.0-0.20201009175936.91497da.el8
+python3-packaging >= 20.4-1.el8ost
+python3-paste >= 3.2.4-1.el8ost
+python3-paste-deploy >= 2.0.1-4.el8ost
+python3-pint >= 0.10.1-1.el8ost
 python3-scciclient
+python3-stevedore >= 3.2.2-0.20201009151242.274eaa6.el8
 python3-sushy
 python3-sushy-oem-idrac
+python3-zipp >= 0.5.1-2.el8ost
 qemu-img

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -3,13 +3,13 @@
 set -euxo pipefail
 
 dnf upgrade -y
-dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${PKGS_LIST})
+xargs -rd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST}
 if [ $(uname -m) = "x86_64" ]; then
     dnf install -y syslinux-nonlinux;
 fi
 if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
-        dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${EXTRA_PKGS_LIST})
+        xargs -rd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${EXTRA_PKGS_LIST}
     fi
 fi
 dnf clean all


### PR DESCRIPTION
To simplify keeping track of minimum installed and required version
of python libraries and ironic packages, we add the versions in
the packages list.
This will also help when cross-tagging packages to test with the
new versions using the prevalidation repositories.