### PR TITLE
Bug 1909730: Prevent unbound variable error in prepare-image

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/bash
 
-set -ex
+set -euxo pipefail
 
 dnf upgrade -y
 dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${PKGS_LIST})
 if [ $(uname -m) = "x86_64" ]; then
     dnf install -y syslinux-nonlinux;
 fi
-if [[ ! -z ${EXTRA_PKGS_LIST} ]]; then
+if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
         dnf --setopt=install_weak_deps=False install -y $(cat /tmp/${EXTRA_PKGS_LIST})
     fi
 fi
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*
+


### PR DESCRIPTION
Also make build process fail if something goes wrong in prepare-image

(cherry picked from commit 1c206964546bb18b0ddca8b47dd4bfe1a2a9ae1e)