### PR TITLE
Bug 1920294: Update version of pyghmi library

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -33,6 +33,7 @@ python3-packaging >= 20.4-1.el8ost
 python3-paste >= 3.2.4-1.el8ost
 python3-paste-deploy >= 2.0.1-4.el8ost
 python3-pint >= 0.10.1-1.el8ost
+python3-pyghmi >= 1.5.14-2.1.el8ost
 python3-scciclient
 python3-stevedore >= 3.2.2-0.20201009151242.274eaa6.el8
 python3-sushy


### PR DESCRIPTION
The old version doesn't work very well with Fujitsu drivers.