### PR TITLE
Bug 1917966: Force update of dnsmasq

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -23,7 +23,7 @@ FROM ubi8
 
 RUN dnf update -y && \
     dnf install -y python3-gunicorn openstack-ironic-api openstack-ironic-conductor crudini \
-        iproute dnsmasq httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
+        iproute "dnsmasq >= 2.79-11.el8_2.2" httpd qemu-img parted gdisk ipxe-bootimgs psmisc procps-ng \
         mariadb-server ipxe-roms-qemu genisoimage python3-ironic-prometheus-exporter \
         python3-jinja2 python3-sushy-oem-idrac && \
     dnf clean all && \


### PR DESCRIPTION
We need to upgrade the dnsmasq version to fix the vulnerability
described in https://access.redhat.com/security/vulnerabilities/RHSB-2021-001