### PR TITLE
Bug 1917938: Update dnsmasq version

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,5 +1,5 @@
 crudini
-dnsmasq
+dnsmasq >= 2.79-13.el8_3.1
 gdisk
 genisoimage
 httpd


### PR DESCRIPTION
We need a new version to fix the security vulnerability described in
https://access.redhat.com/security/vulnerabilities/RHSB-2021-001