### PR TITLE
Bug 1918178: Explicitly set minimum versions of ironic packages

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -26,7 +26,7 @@ ARG PKGS_LIST=main-packages-list.txt
 COPY ${PKGS_LIST} /tmp/main-packages-list.txt
 
 RUN dnf upgrade -y && \
-    dnf --setopt=install_weak_deps=False install -y $(cat /tmp/main-packages-list.txt) && \
+    xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST} && \
     dnf clean all && \
     rm -rf /var/cache/{yum,dnf}/*
 

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -9,8 +9,8 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api
-openstack-ironic-conductor
+openstack-ironic-api >= 16.0.2-0.20201105091209.193b93c.el8
+openstack-ironic-conductor >= 16.0.2-0.20201105091209.193b93c.el8
 parted
 psmisc
 python3-dracclient


### PR DESCRIPTION
To simplify keeping track of minimum installed and required version
of python libraries and ironic packages, we add the versions in
the packages list.
This will also help when cross-tagging packages to test with the
new versions using the prevalidation repositories.

Partial cherry-pick from #132 