### PR TITLE
Bug 1915828: Latest Dell firmware (04.40.00.00) fails to install IPI on BM using idrac-virtualmedia protocol

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -35,7 +35,7 @@ python3-paste-deploy >= 2.0.1-4.el8ost
 python3-pint >= 0.10.1-1.el8ost
 python3-scciclient
 python3-stevedore >= 3.2.2-0.20201009151242.274eaa6.el8
-python3-sushy
+python3-sushy >= 3.6.1-0.20210122201213.7ec0422.el8
 python3-sushy-oem-idrac
 python3-zipp >= 0.5.1-2.el8ost
 qemu-img


### PR DESCRIPTION
This PR contains a fix in the sushy package [1] for the bz [2]

[1] https://github.com/openstack/sushy/commit/dfe6b33fa66072e9ead784d06fa30946ef922cb8
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1915828