### PR TITLE
Bug 1910739: Update ironic version to fix idrac bug

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -10,8 +10,8 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api >= 16.0.3-0.20201219231205.4ae5375.el8
-openstack-ironic-conductor >= 16.0.3-0.20201219231205.4ae5375.el8
+openstack-ironic-api >= 1:16.0.4-0.20210121171221.0e4e00e.el8
+openstack-ironic-conductor >= 1:16.0.4-0.20210121171221.0e4e00e.el8
 parted
 psmisc
 python3-debtcollector >= 2.2.0-0.20201008171245.649189d.el8


### PR DESCRIPTION
Update fixes Redfish-virtualmedia (idrac) deploy fails on
"The Virtual Media image server is already connected"

https://bugzilla.redhat.com/show_bug.cgi?id=1910739