### PR TITLE
Prevent content override of /bin/ when building with imagebuilder

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -35,7 +35,7 @@ COPY config/ironic.conf.j2 /etc/ironic/
 
 # TODO(dtantsur): remove scripts/runironic script when we stop supporting
 # running both API and conductor processes via one entry point.
-COPY scripts/ /bin/
+COPY scripts/* /bin/
 
 COPY config/dnsmasq.conf.j2 /etc/
 COPY inspector.ipxe dualboot.ipxe /tmp/


### PR DESCRIPTION
`podman`, `buildah`, and basically any other image building method merges the new contents of `scripts/` with `/bin/`, but `imagebuilder` overrides them instead.

Test:

Given the following sample Dockerfile:
```
FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8
RUN ls /bin/ | wc -l
COPY scripts/ /bin/
RUN ls /bin/ | wc -l
```

Building it with `buildah`, does what is expected:
```
$ buildah bud
STEP 1: FROM
registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8
STEP 2: RUN ls /bin/ | wc -l
364
STEP 3: COPY scripts/ /bin/
STEP 4: RUN ls /bin/ | wc -l
374
STEP 5: COMMIT
```

But with `imagebuilder`:
```
$ imagebuilder .
--> FROM
registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8 as
0
--> RUN ls /bin/ | wc -l
364
--> COPY scripts/ /bin/
--> RUN ls /bin/ | wc -l
OCI runtime exec failed: exec failed: container_linux.go:370: starting
container process caused: exec: "/bin/sh": stat /bin/sh: no such file or
directory: unknown
running 'ls /bin/ | wc -l' failed with exit code 126
```
* everything is gone from `/bin/`, including `/bin/sh`.

Adding the proposed change:
```
FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8
RUN ls /bin/ | wc -l
COPY scripts/* /bin/
RUN ls /bin/ | wc -l
```

Still works with `buildah`:
```
$ buildah bud
STEP 1: FROM
registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8
STEP 2: RUN ls /bin/ | wc -l
364
STEP 3: COPY scripts/ /bin/
STEP 4: RUN ls /bin/ | wc -l
374
STEP 5: COMMIT
```

And now it makes `imagebuilder` happy too:
```
$ imagebuilder .
--> FROM
registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8 as
0
--> RUN ls /bin/ | wc -l
364
--> COPY scripts/* /bin/
--> RUN ls /bin/ | wc -l
374
--> Committing changes ...
--> Done
```