### PR TITLE
Bug 1937695: Supply a default for COPY args

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -20,7 +20,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 ENV PKGS_LIST=main-packages-list.txt
 ARG EXTRA_PKGS_LIST
 
-COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST} /tmp/
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh /bin/
 
 RUN prepare-image.sh && \


### PR DESCRIPTION
Supplying a blank arg to COPY results in all of
the files in the source directory being copied into
the image into /tmp for docker/podman build (or "/"
if using imagebuilder). Give it a default of a file
that exists to avoid this happening.