### PR TITLE
Bug 1945683: Wait for expected number of drivers starting API

### DIFF
--- a/runironic-api.sh
+++ b/runironic-api.sh
@@ -2,4 +2,14 @@
 
 . /bin/configure-ironic.sh
 
+# Wait for ironic to load all expected drivers
+# the DB query returns the number of unique hardware_type in the conductor_hardware_interfaces table
+CONF_DRIVERS=$(crudini --get /etc/ironic/ironic.conf DEFAULT enabled_hardware_types | tr ',' '\n' | wc -l)
+while true ; do
+  DB_DRIVERS=$(mysql -p$MARIADB_PASSWORD -u ironic -h 127.0.0.1 ironic -e 'select count( DISTINCT hardware_type) from conductor_hardware_interfaces' -B -s --ssl || echo 0)
+  [ "$DB_DRIVERS" -ge "$CONF_DRIVERS" ] && break
+  echo "Waiting for $CONF_DRIVERS expected drivers"
+  sleep 5
+done
+
 exec /usr/bin/ironic-api --config-file /etc/ironic/ironic.conf


### PR DESCRIPTION
Currently the API will start even if the conductor is still
starting up, which can lead to failures if you try to deploy
nodes as soon as the API is accessible.

Co-Author: Steven Hardy <shardy@redhat.com>