### PR TITLE
Bug 1953795: Set webserver_verify_ca to certificate path or false

### DIFF
--- a/config/ironic.conf.j2
+++ b/config/ironic.conf.j2
@@ -35,6 +35,13 @@ host = localhost
 host = {{ env.IRONIC_URL_HOST }}
 {% endif %}
 
+# If a path to a certificate is defined, use that first for webserver
+{% if env.WEBSERVER_CACERT_FILE %}
+webserver_verify_ca =  {{ env.WEBSERVER_CACERT_FILE }}
+{% elif env.IRONIC_INSECURE == "true" %}
+webserver_verify_ca = false
+{% endif %}
+
 isolinux_bin = /usr/share/syslinux/isolinux.bin
 
 # NOTE(dtantsur): this path is specific to the GRUB image that is built into


### PR DESCRIPTION
Set the ironic conf setting `webserver_verify_ca` to a
new WEBSERVER_CACERT_FILE env if defined, or set it
the value of IRONIC_INSECURE if the cert is not defined.

By default it will be set to True.