### PR TITLE
Bug 1953979: Add parameter to set boot iso source

### DIFF
--- a/config/ironic.conf.j2
+++ b/config/ironic.conf.j2
@@ -93,6 +93,9 @@ erase_devices_priority = 0
 http_root = /shared/html/
 http_url = http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}
 fast_track = {{ env.IRONIC_FAST_TRACK }}
+{% if env.IRONIC_BOOT_ISO_SOURCE %}
+ramdisk_image_download_source = {{ env.IRONIC_BOOT_ISO_SOURCE }}
+{% endif %}
 
 [dhcp]
 dhcp_provider = none

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -10,8 +10,8 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api >= 1:17.0.1-0.20210407191221.d6bb66d.el8
-openstack-ironic-conductor >= 1:17.0.1-0.20210407191221.d6bb66d.el8
+openstack-ironic-api >= 1:17.0.3-0.20210506111219.659eef7.el8
+openstack-ironic-conductor >= 1:17.0.3-0.20210506111219.659eef7.el8
 parted
 psmisc
 python3-debtcollector >= 2.2.0-0.20201008171245.649189d.el8


### PR DESCRIPTION
The new ramdisk_image_download_source allows to set where the boot iso
image will be served from.
The new ramdisk_image_download_source allows to set where the boot iso
image will be served from.
Also set ironic version to the change where the option was added [0].

[0] https://opendev.org/openstack/ironic/commit/659eef72ee59fdeb639577c8499406f59644a433

Metal3 change https://github.com/metal3-io/ironic-image/pull/261