### PR TITLE
Bug 1958802: Include fix for CVE-2021-21419

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -16,6 +16,7 @@ parted
 psmisc
 python3-debtcollector >= 2.2.0-0.20201008171245.649189d.el8
 python3-dracclient
+python3-eventlet >= 0.25.2-4.el8
 python3-gunicorn
 python3-ironic-lib >= 4.6.2-0.20210324125107.5d54fe0.el8
 python3-ironic-prometheus-exporter >= 2.2.1-0.20210325143713.70e39c8.el8


### PR DESCRIPTION
python-eventlet: improper handling of highly compressed data and memory
allocation with excessive size allows DoS.