### PR TITLE
Bug 1962905: Revert "Disable caching live boot iso by default"

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -16,9 +16,6 @@ export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
 
 export MARIADB_CACERT_FILE=/certs/ca/mariadb/tls.crt
 
-# Set default live-iso source to http and disable local caching
-export IRONIC_BOOT_ISO_SOURCE=${IRONIC_BOOT_ISO_SOURCE:-"http"}
-
 mkdir -p /certs/ironic
 mkdir -p /certs/ironic-inspector
 mkdir -p /certs/ca/ironic


### PR DESCRIPTION
Ironic's approach to caching ISOs and serving them to Apache is well supported by most BMCs and defaulting to it would increase the compatibility of the solution. Switching the default to "local" should come with documentation of the storage requirements, specially in the usage pattern introduced by the Agent based fully automated provisioning.

This reverts commit 39bd4c55e3e6847a0120f26634a65cf26a2b00e5.