### PR TITLE
Add options for external_http_url and external_callback_url

### DIFF
--- a/config/ironic.conf.j2
+++ b/config/ironic.conf.j2
@@ -96,6 +96,12 @@ fast_track = {{ env.IRONIC_FAST_TRACK }}
 {% if env.IRONIC_BOOT_ISO_SOURCE %}
 ramdisk_image_download_source = {{ env.IRONIC_BOOT_ISO_SOURCE }}
 {% endif %}
+{% if env.IRONIC_EXTERNAL_HTTP_URL %}
+external_http_url = {{ env.IRONIC_EXTERNAL_HTTP_URL }}
+{% endif %}
+{% if env.IRONIC_EXTERNAL_CALLBACK_URL %}
+external_callback_url = {{ env.IRONIC_EXTERNAL_CALLBACK_URL }}
+{% endif %}
 
 [dhcp]
 dhcp_provider = none

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -84,6 +84,15 @@ else
     export MARIADB_TLS_ENABLED="false"
 fi
 
+if [ ! -z "${IRONIC_EXTERNAL_IP}" ]; then
+	if [ "${IRONIC_INSPECTOR_TLS_SETUP}" == "true" ]; then
+		export IRONIC_EXTERNAL_CALLBACK_URL="https://${IRONIC_EXTERNAL_IP}:6385"
+	else
+		export IRONIC_EXTERNAL_CALLBACK_URL="http://${IRONIC_EXTERNAL_IP}:6385"
+	fi
+	export IRONIC_EXTERNAL_HTTP_URL="http://${IRONIC_EXTERNAL_IP}:6180"
+fi
+
 cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 
 # oslo.config also supports Config Opts From Environment, log them


### PR DESCRIPTION
In order to allow provisioning of external nodes, we need to be
able to call back to Ironic on an external IP address.