### PR TITLE
Add support for deriving the PROVISIONING_INTERFACE from a mac address

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ All of the containers must share a common mount point or data store.  Ironic req
 - final image to be deployed onto node in qcow2 format
 
 The following environment variables can be passed in to customize run-time functionality:
-- PROVISIONING_INTERFACE - interface to use for ironic, dnsmasq(dhcpd) and httpd (default provisioning)
+- PROVISIONING_MACS - a comma seperated list of mac address of the master nodes (used to determine the PROVISIONING_INTERFACE)
+- PROVISIONING_INTERFACE - interface to use for ironic, dnsmasq(dhcpd) and httpd (default provisioning, this is calculated if the above PROVISIONING_MACS is provided)
 - DNSMASQ_EXCEPT_INTERFACE - interfaces to exclude when providing DHCP address (default "lo")
 - HTTP_PORT - port used by http server (default 80)
 - DHCP_RANGE - dhcp range to use for provisioning (default 172.22.0.10-172.22.0.100)

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -1,4 +1,21 @@
-export PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+function get_provisioning_interface() {
+  if [ -n "${PROVISIONING_INTERFACE}" ]; then
+    # don't override the PROVISIONING_INTERFACE if one is provided
+    echo ${PROVISIONING_INTERFACE}
+    return
+  fi
+
+  local interface="provisioning"
+  for mac in ${PROVISIONING_MACS//,/ } ; do
+    if ip -br link show up | grep -q "$mac"; then
+      interface=$(ip -br link show up | grep "$mac" | cut -f 1 -d ' ')
+      break
+    fi
+  done
+  echo $interface
+}
+
+export PROVISIONING_INTERFACE=$(get_provisioning_interface)
 
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 function wait_for_interface_or_ip() {


### PR DESCRIPTION
The point of this PR is to allow users to:

    not have to provide the PROVISIONING_INTERFACE (as it has to be the same for all hosts)
    instead make use of the know mac addresses that we have in the bmh.Spec.BootMACAddress to calculate the interface

The cbo PR is here openshift/cluster-baremetal-operator#149