### PR TITLE
Bug 1969212: remove irmc from enabled_bios_interfaces

### DIFF
--- a/config/ironic.conf.j2
+++ b/config/ironic.conf.j2
@@ -10,7 +10,7 @@ default_boot_interface = ipxe
 default_deploy_interface = direct
 default_inspect_interface = inspector
 default_network_interface = noop
-enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish,irmc
+enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish
 enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
 enabled_deploy_interfaces = direct,fake,ramdisk
 # NOTE(dtantsur): when changing this, make sure to update the driver


### PR DESCRIPTION
When bios_interface is set to irmc, the master will continue to restart during the IPI
configuration process, so temporarily remove irmc from enabled_bios_interfaces.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>