### PR TITLE
Bug 1975137: [4.8] Sync image with the latest ironic code

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -10,8 +10,8 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api >= 1:17.0.3-0.20210518121213.77be4c6.el8
-openstack-ironic-conductor >= 1:17.0.3-0.20210518121213.77be4c6.el8
+openstack-ironic-api >= 1:17.0.3-0.20210622161212.48cedc0.el8
+openstack-ironic-conductor >= 1:17.0.3-0.20210622161212.48cedc0.el8
 parted
 psmisc
 python3-debtcollector >= 2.2.0-0.20210324220630.649189d.el8

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -10,8 +10,8 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api >= 1:17.0.3-0.20210622161212.48cedc0.el8
-openstack-ironic-conductor >= 1:17.0.3-0.20210622161212.48cedc0.el8
+openstack-ironic-api >= 1:17.0.4-0.20210713221218.a415e7e.el8
+openstack-ironic-conductor >= 1:17.0.4-0.20210713221218.a415e7e.el8
 parted
 psmisc
 python3-debtcollector >= 2.2.0-0.20210324220630.649189d.el8


### PR DESCRIPTION
Include some recent bugfixes from ironic upstream code, for example:

https://opendev.org/openstack/ironic/commit/48cedc067a2436f60de10bb9cdfb1e29f57928ee
https://opendev.org/openstack/ironic/commit/ff05ba063e8842e4de97f908eed5a9e90239f1a5
https://opendev.org/openstack/ironic/commit/4037ae147af3b3b9a1a2e732a6e4ea732e2f51fc