### PR TITLE
Support IPA running on top of CoreOS

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -36,7 +36,7 @@ COPY --from=builder /tmp/esp.img /tmp/uefi_esp.img
 
 COPY ironic-config/ironic.conf.j2 /etc/ironic/
 COPY ironic-config/dnsmasq.conf.j2 /etc/
-COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe /tmp/
+COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe ironic-config/ironic-python-agent.ign.j2 /tmp/
 
 # Custom httpd config, removes all but the bare minimum needed modules
 RUN rm -f /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -51,7 +51,7 @@ COPY ./runlogwatch.sh /bin/runlogwatch.sh
 COPY ./runironic.sh /bin/runironic
 
 COPY ./dnsmasq.conf.j2 /etc/dnsmasq.conf.j2
-COPY config/inspector.ipxe.j2 config/dualboot.ipxe /tmp/
+COPY ironic-config/inspector.ipxe.j2 ironic-config/dualboot.ipxe ironic-config/ironic-python-agent.ign.j2 /tmp/
 
 # Custom httpd config, removes all but the bare minimum needed modules
 RUN rm -f /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf

--- a/ironic-config/ironic-python-agent.ign.j2
+++ b/ironic-config/ironic-python-agent.ign.j2
@@ -1,0 +1,59 @@
+{% set service %}
+[Unit]
+Description=Ironic Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+TimeoutStartSec=0
+ExecStartPre=/bin/podman pull {{ env.IRONIC_AGENT_REGISTRY }}/ironic-agent --tls-verify=false
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent ironic-agent
+
+[Install]
+WantedBy=multi-user.target
+{% endset -%}
+
+{% set ipa_config %}
+[DEFAULT]
+api_url = {{ env.IRONIC_BASE_URL }}:6385
+inspection_callback_url = {{ env.IRONIC_BASE_URL }}:5050/v1/continue
+
+collect_lldp = True
+enable_vlan_interfaces = {{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }}
+inspection_collectors = default,extra-hardware,logs
+inspection_dhcp_all_interfaces = True
+{% endset -%}
+
+
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  {% if env.IRONIC_RAMDISK_SSH_KEY %}
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "{{ env.IRONIC_RAMDISK_SSH_KEY | trim }}"
+        ]
+      }
+    ]
+  },
+  {% endif -%}
+  "storage": {
+    "files": [{
+      "path": "/etc/ironic-python-agent.conf",
+      "contents": {"source": "data:,{{ ipa_config | urlencode }}"}
+    }]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "{{ service | trim | replace('\n', '\\n') }}",
+        "enabled": true,
+        "name": "ironic-agent.service"
+      }
+    ]
+  }
+}

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -107,10 +107,10 @@ power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 cafile = {{ env.IRONIC_INSPECTOR_CACERT_FILE }}
 insecure = {{ env.IRONIC_INSPECTOR_INSECURE }}
 {% endif %}
-# TODO(dtantsur): ipa-api-url should be populated by ironic itself, but it's
-# not, so working around here.
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
-extra_kernel_params = ipa-insecure=1 ipa-inspection-collectors=default,extra-hardware,logs ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {% if env.IRONIC_FAST_TRACK == "true" %} ipa-api-url={{ env.IRONIC_BASE_URL }} {% endif %}{% if env.IRONIC_RAMDISK_SSH_KEY %} sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}
+# Also keep in mind that only parameters unique for inspection go here.
+# No need to duplicate pxe_append_params/kernel_append_params.
+extra_kernel_params = ipa-inspection-collectors=default,extra-hardware,logs ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1
 
 [ipmi]
 # use_ipmitool_retries transfers the responsibility of retrying to ipmitool
@@ -179,6 +179,9 @@ enable_netboot_fallback = true
 
 [redfish]
 use_swift = false
+kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}
+
+[ilo]
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}
 
 [service_catalog]

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -12,7 +12,7 @@ default_inspect_interface = inspector
 default_network_interface = noop
 enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish
 enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media,idrac-redfish-virtual-media
-enabled_deploy_interfaces = direct,fake,ramdisk
+enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
 enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,manual-management

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,3 +1,4 @@
+coreos-installer
 crudini
 dnsmasq >= 2.79-13.el8_3.1
 gdisk

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+. /bin/ironic-common.sh
+. /bin/coreos-ipa-common.sh
+
+export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
+
+IRONIC_CERT_FILE=/certs/ironic/tls.crt
+
+# FIXME(dtantsur): the default is most certainly undesired
+export IRONIC_AGENT_REGISTRY=${IRONIC_AGENT_REGISTRY:-quay.io/dtantsur}
+
+wait_for_interface_or_ip
+
+if [ -f "$IRONIC_CERT_FILE" ]; then
+    export IRONIC_BASE_URL="https://${IRONIC_URL_HOST}"
+else
+    export IRONIC_BASE_URL="http://${IRONIC_URL_HOST}"
+fi
+
+render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
+coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -145,6 +145,8 @@ EOF
     fi
 fi
 
+. /bin/coreos-ipa-common.sh
+
 # The original ironic.conf is empty, and can be found in ironic.conf_orig
 render_j2_config /etc/ironic/ironic.conf.j2 /etc/ironic/ironic.conf
 

--- a/scripts/coreos-ipa-common.sh
+++ b/scripts/coreos-ipa-common.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash
+
+ROOTFS_FILE=/shared/html/images/ironic-python-agent.rootfs
+IGNITION_FILE=/shared/html/ironic-python-agent.ign
+ISO_FILE=/shared/html/images/ironic-python-agent.iso
+
+function coreos_kernel_params {
+    echo -n "coreos.live.rootfs_url=http://$IRONIC_IP:$HTTP_PORT/images/ironic-python-agent.rootfs"
+    echo -n " ignition.config.url=http://$IRONIC_IP:$HTTP_PORT/ironic-python-agent.ign"
+    echo " ignition.firstboot ignition.platform.id=metal"
+}
+
+function use_coreos_ipa {
+    [ -f "$ROOTFS_FILE" ] && [ -f "$IGNITION_FILE" ] && return 0 || return 1
+}
+
+if use_coreos_ipa; then
+    export IRONIC_KERNEL_PARAMS="${IRONIC_KERNEL_PARAMS:-} $(coreos_kernel_params)"
+fi

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -25,6 +25,8 @@ else
     INSPECTOR_EXTRA_ARGS=" ipa-inspection-callback-url=${IRONIC_BASE_URL}:5050/v1/continue"
 fi
 
+. /bin/coreos-ipa-common.sh
+
 # Copy files to shared mount
 render_j2_config /tmp/inspector.ipxe.j2 /shared/html/inspector.ipxe
 cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe


### PR DESCRIPTION
* Clean up [inspector]extra_kernel_params
* Enable the custom-agent deploy interface
* Allow configuring CoreOS IPA as a new entrypoint