### PR TITLE
Custom deploy: do not require an ISO

### DIFF
--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -3,6 +3,8 @@
 . /bin/ironic-common.sh
 . /bin/coreos-ipa-common.sh
 
+set -x
+
 export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
 
 IRONIC_CERT_FILE=/certs/ironic/tls.crt
@@ -19,6 +21,9 @@ else
 fi
 
 render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
+# Print the generated ignition for debugging purposes.
+cat "$IGNITION_FILE"
+
 if [ -f "$ISO_FILE" ]; then
     coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"
 fi

--- a/scripts/configure-coreos-ipa
+++ b/scripts/configure-coreos-ipa
@@ -19,4 +19,6 @@ else
 fi
 
 render_j2_config /tmp/ironic-python-agent.ign.j2 "$IGNITION_FILE"
-coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"
+if [ -f "$ISO_FILE" ]; then
+    coreos-installer iso ignition embed -i "$IGNITION_FILE" -f "$ISO_FILE"
+fi


### PR DESCRIPTION
It is possible to only use PXE artefacts, in which case we need to
generate an ignition file, but don't need to customize the ISO.

Increase verbosity of configure-coreos-ipa for debugging.