### PR TITLE
Bug 1989839: Prevent installing docs via a DNF flag

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -2,14 +2,18 @@
 
 set -euxo pipefail
 
+echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+# Tell RPM to skip installing documentation
+echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
+
 dnf upgrade -y
-xargs -rd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST}
+xargs -rd'\n' dnf install -y < /tmp/${PKGS_LIST}
 if [ $(uname -m) = "x86_64" ]; then
     dnf install -y syslinux-nonlinux;
 fi
 if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
     if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
-        xargs -rd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${EXTRA_PKGS_LIST}
+        xargs -rd'\n' dnf install -y < /tmp/${EXTRA_PKGS_LIST}
     fi
 fi
 dnf clean all


### PR DESCRIPTION
This change adds a flag that disables installing documentation from
RPMs. Additionally, prevent installing weak dependencies globally.

(cherry picked from commit 178b7675ea57c02b67f2614a2267eedf219e0b8e)

metal3-io PR https://github.com/metal3-io/ironic-image/pull/281