### PR TITLE
Bug 1986238: Supermicro X12 fails to provision using Redfish BM HW Provisioning

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -47,7 +47,7 @@ python3-pyghmi >= 1.5.14-2.1.el8ost
 python3-tooz >= 2.8.0-0.20210324235001.54448e9.el8
 python3-scciclient >= 0.9.1-0.20210720102209.34ccd96.el8
 python3-stevedore >= 3.3.0-0.20210325001012.7d7154f.el8
-python3-sushy >= 3.9.2-0.20210713222215.21ec275.el8
+python3-sushy >= 3.11.0-0.20210802160404.b93dcba.el8
 python3-sushy-oem-idrac >= 2.0.1-0.20210326153413.83b7eb0.el8
 python3-zipp >= 0.5.1-2.el8ost
 qemu-img


### PR DESCRIPTION
This commit updates ironic-images so that this sushy fix:
https://review.opendev.org/c/openstack/sushy/+/803197
is included.