### PR TITLE
Bug 1991979: [4.8] Sync image with ironic

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -10,8 +10,8 @@ ipxe-bootimgs
 ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
-openstack-ironic-api >= 1:17.0.4-0.20210713221218.a415e7e.el8
-openstack-ironic-conductor >= 1:17.0.4-0.20210713221218.a415e7e.el8
+openstack-ironic-api >= 1:17.0.4-0.20210730151213.5b801be.el8
+openstack-ironic-conductor >= 1:17.0.4-0.20210730151213.5b801be.el8
 parted
 psmisc
 python3-debtcollector >= 2.2.0-0.20210324220630.649189d.el8


### PR DESCRIPTION
Include recent bug fixes from upstream code:
https://github.com/openstack/ironic/commit/8f6a2eacebdc767d98a3c0737329bf8825c1adcb
https://github.com/openstack/ironic/commit/5b801be7a456e31c5111971a3ecc2ad140b19ea5