### PR TITLE
Bug 1993078: Restore auth config to ironic-api

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -1,5 +1,10 @@
 [DEFAULT]
+{% if env.IRONIC_HTTPD == "false" and "HTTP_BASIC_HTPASSWD" in env and env.HTTP_BASIC_HTPASSWD | length %}
+auth_strategy = http_basic
+http_basic_auth_user_file = /etc/ironic/htpasswd
+{% else %}
 auth_strategy = noauth
+{% endif %}
 debug = true
 default_deploy_interface = direct
 default_inspect_interface = inspector

--- a/scripts/runironic-api
+++ b/scripts/runironic-api
@@ -1,10 +1,9 @@
 #!/usr/bin/bash
 
 export IRONIC_DEPLOYMENT="API"
+export IRONIC_HTTPD=${IRONIC_HTTPD:-"false"}
 
 . /bin/configure-ironic.sh
-
-IRONIC_HTTPD=${IRONIC_HTTPD:-"false"}
 
 if [ "$IRONIC_HTTPD" == "true" ]; then
     python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /etc/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf


### PR DESCRIPTION
Auth was removed from ironic API in favour of doing
it in httpd (as part of a switch to wsgi). The switch to
wsgi hasn't happened so we need to restore auth here.