### PR TITLE
OWNERS: add iurygregory, remove stbenjam

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,14 +3,15 @@ approvers:
   - derekhiggins
   - dtantsur
   - elfosardo
+  - iurygregory
   - hardys
-  - stbenjam
   - zaneb
 reviewers:
   - bfournie
   - derekhiggins
   - dtantsur
   - elfosardo
+  - iurygregory
   - hardys
   - zaneb
 


### PR DESCRIPTION
He's the current Ironic PTL (project team lead) and is well familiar
with the code, as well as the way images are built and shipped.

Stephen is moving on to different responsibilities and is not very active
on ironic-image anyway.
