### PR TITLE
Bug 2010698: Compare IPs using the short form of IPv6 address

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -5,6 +5,7 @@ gdisk
 genisoimage
 httpd
 httpd-tools
+ipcalc
 ipmitool
 iproute
 ipxe-bootimgs

--- a/main-packages-list.okd
+++ b/main-packages-list.okd
@@ -5,6 +5,7 @@ gdisk
 genisoimage
 httpd
 httpd-tools
+ipcalc
 ipmitool
 iproute
 ipxe-bootimgs

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -22,7 +22,8 @@ function wait_for_interface_or_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
-    export IRONIC_IP=$(printf %s "${PROVISIONING_IP}" | sed -e 's%/.*%%')
+    # Convert the address using ipcalc which strips out the subnet. For IPv6 addresses, this will give the short-form address
+    export IRONIC_IP=$(ipcalc -s "${PROVISIONING_IP}" | grep "^Address:" | awk '{print $2}')
     until ip -br addr show | grep -q -F " ${IRONIC_IP}/"; do
       echo "Waiting for ${IRONIC_IP} to be configured on an interface"
       sleep 1


### PR DESCRIPTION
The ip command returns the short-form of the IPv6 address so that is what should be used for comparison, even if the user entered an IPv6 address in long-form for PROVISIONING_IP. Use ipcalc to get the short-form address. This command can also be used for IPv4 as it strips out the subnet mask for IPv4 and IPv6.

For the PROVISIONING_IPs below, this is what would be set for IRONIC_IP:
fdcc:aaaa:00bb:c1d0::3 -> fdcc:aaaa:bb:c1d0::3
fdcc:aaaa:00bb:c1d0:0000:0000:0000:0003 -> fdcc:aaaa:bb:c1d0::3
fdcc:aaaa:00bb:c1d0::3/64 -> fdcc:aaaa:bb:c1d0::3
fdcc:aaaa:00bb:c1d0::3/128 -> fdcc:aaaa:bb:c1d0::3
10.10.10.1 -> 10.10.10.1
10.10.10.1/24 -> 10.10.10.1
10.10.10.1/64 ->