### PR TITLE
Bug 2012798: Ironic resumes clean before raid configuration job is actually completed

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -12,8 +12,8 @@ ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
 mod_ssl
-openstack-ironic-api >= 1:18.1.1-0.20210812092216.4aec741.el8
-openstack-ironic-conductor >= 1:18.1.1-0.20210812092216.4aec741.el8
+openstack-ironic-api >= 1:18.1.1-0.20211006122217.5134847.el8
+openstack-ironic-conductor >= 1:18.1.1-0.20211006122217.5134847.el8
 openstack-ironic-inspector >= 10.7.1-0.20210722154052.edf655c.el8
 parted
 psmisc


### PR DESCRIPTION
This commit updates ironic-images so that these fixes:
https://review.opendev.org/c/openstack/ironic/+/812433
https://review.opendev.org/c/openstack/ironic/+/812434
are included.