### PR TITLE
Bug 2025754: Enable vMedia provisioning of SuperMicro X11/X12

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -47,7 +47,7 @@ python3-pyghmi >= 1.5.14-2.1.el8ost
 python3-tooz >= 2.8.0-0.20210324235001.54448e9.el8
 python3-scciclient >= 0.9.1-0.20210720102209.34ccd96.el8
 python3-stevedore >= 3.3.0-0.20210325001012.7d7154f.el8
-python3-sushy >= 3.11.0-0.20210802160404.b93dcba.el8
+python3-sushy >= 3.12.1-0.20211122142104.806622c.el8
 python3-sushy-oem-idrac >= 2.0.1-0.20210326153413.83b7eb0.el8
 python3-zipp >= 0.5.1-2.el8ost
 qemu-img


### PR DESCRIPTION
This commit brings in the upstream OpenStack/Sushy fix required
for virtual media based provisioning of SuperMicro X11 and X12
into OpenShift:

https://review.opendev.org/c/openstack/sushy/+/818369