### PR TITLE
Don't always pass ignition config in PXE kernel args

### DIFF
--- a/scripts/coreos-ipa-common.sh
+++ b/scripts/coreos-ipa-common.sh
@@ -6,12 +6,14 @@ ISO_FILE=${ISO_FILE:-/shared/html/images/ironic-python-agent.iso}
 
 function coreos_kernel_params {
     echo -n "coreos.live.rootfs_url=http://$IRONIC_IP:$HTTP_PORT/images/ironic-python-agent.rootfs"
-    echo -n " ignition.config.url=http://$IRONIC_IP:$HTTP_PORT/ironic-python-agent.ign"
+    if [ -f "$IGNITION_FILE" ]; then
+        echo -n " ignition.config.url=http://$IRONIC_IP:$HTTP_PORT/ironic-python-agent.ign"
+    fi
     echo " ignition.firstboot ignition.platform.id=metal"
 }
 
 function use_coreos_ipa {
-    [ -f "$ROOTFS_FILE" ] && [ -f "$IGNITION_FILE" ] && return 0 || return 1
+    [ -f "$ROOTFS_FILE" ] && return 0 || return 1
 }
 
 if use_coreos_ipa; then


### PR DESCRIPTION
When we get images from the image builder, they will contain the
Ignition file. Only pass an Ignition URL on the kernel command line if
the configure-coreos-ipa script has been run to create an ignition file
locally. We will not run this script when using the image builder.

However, we always want to set the rootfs location in the kernel args,
even when we haven't run configure-coreos-ipa because we are using the
image builder instead.

(Upstream PR is metal3-io#331)