### PR TITLE
Disable the node history feature

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -78,6 +78,8 @@ send_sensor_data = {{ env.SEND_SENSOR_DATA }}
 send_sensor_data_interval = 160
 bootloader = http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/uefi_esp.img
 verify_step_priority_override = management.clear_job_queue:90
+# We don't use this feature, and it creates an additional load on the database
+node_history = False
 
 [database]
 {% if env.MARIADB_TLS_ENABLED == "true" %}


### PR DESCRIPTION
This new feature provides a history of all events for a node. We don't
use it, and it creates an additional load on the database. Disable.

Upstream: https://github.com/metal3-io/ironic-image/pull/336
