### PR TITLE
Bug 2032573: Update ironic to include latest major bugfixes

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -13,8 +13,8 @@ ipxe-roms-qemu
 iscsi-initiator-utils
 mariadb-server
 mod_ssl
-openstack-ironic-api >= 1:19.0.1-0.20211210165034.c86ca20.el8
-openstack-ironic-conductor >= 1:19.0.1-0.20211210165034.c86ca20.el8
+openstack-ironic-api >= 1:19.0.1-0.20211220164057.e09f09f.el8
+openstack-ironic-conductor >= 1:19.0.1-0.20211220164057.e09f09f.el8
 openstack-ironic-inspector >= 10.9.1-0.20211209161020.21209f3.el8
 parted
 psmisc


### PR DESCRIPTION
Do not validate boot interface when local booting [1]
Fix redfish update_firmware for newer Sushy [2]

[1] https://opendev.org/openstack/ironic/commit/d5c47ac862d8afbd23e0cac2aef58dd83e665af9
[2] https://opendev.org/openstack/ironic/commit/e09f09f689e25b46ee41a32210717c0a51c2d499