### PR TITLE
Drop unused ipxe.efi

### DIFF
--- a/prepare-ipxe.sh
+++ b/prepare-ipxe.sh
@@ -13,12 +13,3 @@ mkdir -p /tftpboot
 
 cp /usr/share/ipxe/undionly.kpxe /tftpboot/
 cp /usr/share/ipxe/ipxe-snponly-x86_64.efi /tftpboot/snponly.efi
-
-if [ -f "/usr/share/ipxe/ipxe.efi" ]; then
-    cp /usr/share/ipxe/ipxe.efi /tftpboot/ipxe.efi
-elif [ -f "/usr/share/ipxe/ipxe-x86_64.efi" ]; then
-    cp  /usr/share/ipxe/ipxe-x86_64.efi /tftpboot/ipxe.efi
-else
-    echo "Fatal Error - Failed to find ipxe binary"
-    exit 1
-fi

--- a/scripts/rundnsmasq
+++ b/scripts/rundnsmasq
@@ -12,7 +12,7 @@ mkdir -p /shared/html/images
 mkdir -p /shared/html/pxelinux.cfg
 
 # Copy files to shared mount
-cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
+cp /tftpboot/undionly.kpxe /tftpboot/snponly.efi /shared/tftpboot
 
 # Template and write dnsmasq.conf
 python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf


### PR DESCRIPTION
https://github.com/openshift/ironic-image/pull/76 seems to have removed the last use of ipxe.efi in favour of snponly.efi.

This will also help verify which ipxe artifacts are actually required for ARM BM IPI enablement (see https://bugzilla.redhat.com/show_bug.cgi?id=2059350).

