### PR TITLE
[OCP 4.11 only] Backport the kernel params patch

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -42,3 +42,9 @@ RUN mkdir -p /var/lib/ironic /var/lib/ironic-inspector && \
 # IRONIC-INSPECTOR #
 COPY ironic-inspector-config/ironic-inspector.conf.j2 /etc/ironic-inspector/
 COPY ironic-inspector-config/inspector-apache.conf.j2 /etc/httpd/conf.d/
+
+COPY patches/* /tmp/
+# Needed for https://github.com/openshift/enhancements/pull/1059
+# Remove after the first package sync in 4.12.
+RUN cd /usr/lib/python3.6/site-packages && \
+    patch -p1 -f /tmp/patches/001-Allow-reusing-defaults-in-per-node-kernel_append_params.patch

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -14,6 +14,7 @@ openstack-ironic >= 1:20.1.1-0.20220407160303.e5626ab.el8
 openstack-ironic-api >= 1:20.1.1-0.20220407160303.e5626ab.el8
 openstack-ironic-conductor >= 1:20.1.1-0.20220407160303.e5626ab.el8
 openstack-ironic-inspector >= 10.10.0-0.20220216022835.567b731.el8
+patch
 python3-debtcollector >= 2.3.0-0.20211012161119.0bf5bf5.el8
 python3-dracclient >= 7.0.0-0.20211012182751.d26664e.el8
 python3-eventlet >= 0.30.2-1.el8

--- a/patches/001-Allow-reusing-defaults-in-per-node-kernel_append_params.patch
+++ b/patches/001-Allow-reusing-defaults-in-per-node-kernel_append_params.patch
@@ -1,0 +1,127 @@
+commit 5feb39844ab1a3f266669f01b6a13f39462b4612
+Author: Dmitry Tantsur <dtantsur@protonmail.com>
+Date:   Mon Apr 11 18:48:13 2022 +0200
+
+    Allow reusing defaults in per-node kernel_append_params
+    
+    It may be convenient to use [pxe/redfish/...]kernel_append_params as
+    the universal defaults, while using {driver,instance}_info to only
+    append values. This change allows that by replacing %default% with
+    the value of the applicable configuration option.
+    
+    An example use case: CoreOS requires an additional artifact (root
+    filesystem URL) when PXE booting.
+    
+    While here, fix the PXE/iPXE interface documentation.
+    
+    Change-Id: I829291ab5cc19ec2ca43bc45815d012697f0b408
+
+diff --git a/ironic/drivers/modules/ilo/boot.py b/ironic/drivers/modules/ilo/boot.py
+index 5087e3998..7f5c5adcf 100644
+--- a/ironic/drivers/modules/ilo/boot.py
++++ b/ironic/drivers/modules/ilo/boot.py
+@@ -74,12 +74,8 @@ OPTIONAL_PROPERTIES = {
+     'ilo_add_certificates': _("Boolean value that indicates whether the "
+                               "certificates require to be added to the "
+                               "iLO."),
+-    'kernel_append_params': _("Additional kernel parameters to pass down "
+-                              "to instance kernel. These parameters can "
+-                              "be consumed by the kernel or by the "
+-                              "applications by reading /proc/cmdline. "
+-                              "Mind severe cmdline size limit. Overrides "
+-                              "[ilo]/kernel_append_params ironic option.")
++    'kernel_append_params': driver_utils.KERNEL_APPEND_PARAMS_DESCRIPTION %
++    {'option_group': 'ilo'},
+ }
+ COMMON_PROPERTIES = REQUIRED_PROPERTIES
+ 
+diff --git a/ironic/drivers/modules/irmc/boot.py b/ironic/drivers/modules/irmc/boot.py
+index 1195a0670..84964bd2f 100644
+--- a/ironic/drivers/modules/irmc/boot.py
++++ b/ironic/drivers/modules/irmc/boot.py
+@@ -80,13 +80,8 @@ OPTIONAL_PROPERTIES = {
+           "the IPv4 subnet mask that the storage network is configured to "
+           "utilize, in a range between 1 and 31 inclusive. This is necessary "
+           "for booting a node from a remote iSCSI volume. Optional."),
+-    'kernel_append_params': _("Additional kernel parameters to pass down to "
+-                              "instance kernel. These parameters can be "
+-                              "consumed by the kernel or by the applications "
+-                              "by reading /proc/cmdline. Mind severe cmdline "
+-                              "size limit. Overrides "
+-                              "[irmc]/kernel_append_params ironic "
+-                              "option."),
++    'kernel_append_params': driver_utils.KERNEL_APPEND_PARAMS_DESCRIPTION %
++    {'option_group': 'irmc'},
+ }
+ 
+ COMMON_PROPERTIES = REQUIRED_PROPERTIES.copy()
+diff --git a/ironic/drivers/modules/pxe_base.py b/ironic/drivers/modules/pxe_base.py
+index a89c9e443..317b65b85 100644
+--- a/ironic/drivers/modules/pxe_base.py
++++ b/ironic/drivers/modules/pxe_base.py
+@@ -50,13 +50,8 @@ RESCUE_PROPERTIES = {
+                         'required for rescue mode.'),
+ }
+ OPTIONAL_PROPERTIES = {
+-    'kernel_append_params': _("Additional kernel parameters to pass down to "
+-                              "instance kernel. These parameters can be "
+-                              "consumed by the kernel or by the applications "
+-                              "by reading /proc/cmdline. Mind severe cmdline "
+-                              "size limit. Overrides "
+-                              "[pxe]/kernel_append_params ironic "
+-                              "option."),
++    'kernel_append_params': driver_utils.KERNEL_APPEND_PARAMS_DESCRIPTION %
++    {'option_group': 'pxe'},
+ }
+ COMMON_PROPERTIES = REQUIRED_PROPERTIES.copy()
+ COMMON_PROPERTIES.update(driver_utils.OPTIONAL_PROPERTIES)
+diff --git a/ironic/drivers/modules/redfish/boot.py b/ironic/drivers/modules/redfish/boot.py
+index 55c826fc6..1ce05ced9 100644
+--- a/ironic/drivers/modules/redfish/boot.py
++++ b/ironic/drivers/modules/redfish/boot.py
+@@ -46,13 +46,8 @@ OPTIONAL_PROPERTIES = {
+                               "driver should use virtual media USB or floppy "
+                               "device for passing configuration information "
+                               "to the ramdisk. Defaults to False. Optional."),
+-    'kernel_append_params': _("Additional kernel parameters to pass down to "
+-                              "instance kernel. These parameters can be "
+-                              "consumed by the kernel or by the applications "
+-                              "by reading /proc/cmdline. Mind severe cmdline "
+-                              "size limit. Overrides "
+-                              "[redfish]/kernel_append_params ironic "
+-                              "option."),
++    'kernel_append_params': driver_utils.KERNEL_APPEND_PARAMS_DESCRIPTION %
++    {'option_group': 'redfish'},
+     'bootloader': _("URL or Glance UUID  of the EFI system partition "
+                     "image containing EFI boot loader. This image will be "
+                     "used by ironic when building UEFI-bootable ISO "
+diff --git a/ironic/drivers/utils.py b/ironic/drivers/utils.py
+index 5e1596eb4..fc5cdcf0d 100644
+--- a/ironic/drivers/utils.py
++++ b/ironic/drivers/utils.py
+@@ -384,6 +384,17 @@ OPTIONAL_PROPERTIES = {
+ }
+ 
+ 
++KERNEL_APPEND_PARAMS_DESCRIPTION = _(
++    "Additional kernel parameters to pass down to instance kernel. "
++    "These parameters can be consumed by the kernel or by the applications "
++    "by reading /proc/cmdline. Mind severe cmdline size limit. "
++    "When used with virtual media, only applies to ISO images that Ironic "
++    "builds, but not to pre-built ISOs provided via e.g. deploy_iso. "
++    "Overrides the [%(option_group)s]/kernel_append_params configuration "
++    "option, use %%default%% to insert its value."
++)
++
++
+ def get_kernel_append_params(node, default):
+     """Get the applicable kernel params.
+ 
+@@ -399,7 +410,7 @@ def get_kernel_append_params(node, default):
+     for location in ('instance_info', 'driver_info'):
+         result = getattr(node, location).get('kernel_append_params')
+         if result is not None:
+-            return result
++            return result.replace('%default%', default or '')
+ 
+     return default


### PR DESCRIPTION
Backports Ironic commit 5feb39844ab1a3f266669f01b6a13f39462b4612 to 4.11.
Required by:
- https://github.com/openshift/enhancements/pull/1059
- https://github.com/metal3-io/baremetal-operator/pull/1109
