### PR TITLE
Bug 2048672: Enable vMedia provisioning of Nokia servers

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -43,7 +43,7 @@ python3-pyghmi >= 1.5.14-2.1.el8ost
 python3-tooz >= 2.8.0-0.20210324235001.54448e9.el8
 python3-scciclient
 python3-stevedore >= 3.3.0-0.20210325001012.7d7154f.el8
-python3-sushy >= 3.7.4-0.20211119091058.2cc60dc.el8
+python3-sushy >= 3.7.4-0.20220512101453.e0d5bde.el8
 python3-sushy-oem-idrac >= 2.0.1-0.20210326152858.83b7eb0.el8
 python3-zipp >= 0.5.1-2.el8ost
 qemu-img


### PR DESCRIPTION
This commit brings the upstream OpenStack/Sushy fixes required
for virtual media based provisioning of Nokia servers into
OpenShift:

https://review.opendev.org/c/openstack/sushy/+/840653
https://review.opendev.org/c/openstack/sushy/+/840654
https://review.opendev.org/c/openstack/sushy/+/840655