### PR TITLE
Bug 2088196: Backport weak eTag handling fix to OpenShift 4.8

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -43,7 +43,7 @@ python3-pyghmi >= 1.5.14-2.1.el8ost
 python3-tooz >= 2.8.0-0.20210324235001.54448e9.el8
 python3-scciclient
 python3-stevedore >= 3.3.0-0.20210325001012.7d7154f.el8
-python3-sushy >= 3.7.4-0.20220512101453.e0d5bde.el8
+python3-sushy >= 3.7.5-0.20220520231118.041c8ee.el8
 python3-sushy-oem-idrac >= 2.0.1-0.20210326152858.83b7eb0.el8
 python3-zipp >= 0.5.1-2.el8ost
 qemu-img


### PR DESCRIPTION
This commit backports an upstream change in OpenStack/Sushy which 
resolves BZ2088196 in OpenShift 4.8:

https://review.opendev.org/c/openstack/sushy/+/842462