### PR TITLE
Bug 2088319: Backport weak eTag handling fix to OpenShift 4.9

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -48,7 +48,7 @@ python3-pyghmi >= 1.5.14-2.1.el8ost
 python3-tooz >= 2.8.0-0.20210324235001.54448e9.el8
 python3-scciclient >= 0.9.1-0.20210720102209.34ccd96.el8
 python3-stevedore >= 3.3.0-0.20210325001012.7d7154f.el8
-python3-sushy >= 3.12.1-0.20220512112437.2b2417e.el8
+python3-sushy >= 3.12.2-0.20220520212108.9baa774.el8
 python3-sushy-oem-idrac >= 2.0.1-0.20210326153413.83b7eb0.el8
 python3-zipp >= 0.5.1-2.el8ost
 qemu-img


### PR DESCRIPTION
This commit backports an upstream change in OpenStack/Sushy which
resolves BZ2088319 in OpenShift 4.9:

https://review.opendev.org/c/openstack/sushy/+/842461