### PR TITLE
Bug 2087213: Ironic Fix for ZTP with 4.11

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -11,9 +11,9 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:20.2.1-0.20220601105045.c735a2a.el8
-openstack-ironic-api >= 1:20.2.1-0.20220601105045.c735a2a.el8
-openstack-ironic-conductor >= 1:20.2.1-0.20220601105045.c735a2a.el8
+openstack-ironic >= 1:20.2.1-0.20220628175043.b5ed57a.el8
+openstack-ironic-api >= 1:20.2.1-0.20220628175043.b5ed57a.el8
+openstack-ironic-conductor >= 1:20.2.1-0.20220628175043.b5ed57a.el8
 openstack-ironic-inspector >= 10.12.1-0.20220513095437.6dd37e5.el8
 python3-debtcollector >= 2.5.0-0.20220509211533.a6b46c5.el8
 python3-dracclient >= 8.0.0-0.20220509201613.9c7499c.el8


### PR DESCRIPTION
This commit bumps the ironic version to the latest brew build [1]
that includes the fix for BZ2087213 [2]

[1] https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2069315
[2] https://opendev.org/openstack/ironic/commit/b5ed57a60001894ebc5ed56ec39eca0c3ee518fc