### PR TITLE
METAL-256: Add a new entry point for the Ironic proxy

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -33,6 +33,7 @@ COPY ironic-config/httpd.conf /etc/httpd/conf.d/
 COPY ironic-config/httpd-modules.conf /etc/httpd/conf.modules.d/
 COPY ironic-config/apache2-ironic-api.conf.j2 /etc/httpd-ironic-api.conf.j2
 COPY ironic-config/apache2-vmedia.conf.j2 /etc/httpd-vmedia.conf.j2
+COPY ironic-config/apache2-proxy.conf.j2 /etc/httpd-proxy.conf.j2
 
 RUN mkdir -p /var/lib/ironic /var/lib/ironic-inspector && \
   sqlite3 /var/lib/ironic/ironic.db "pragma journal_mode=wal" && \

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -37,6 +37,7 @@ COPY ironic-config/httpd.conf /etc/httpd/conf.d/
 COPY ironic-config/httpd-modules.conf /etc/httpd/conf.modules.d/
 COPY ironic-config/apache2-ironic-api.conf.j2 /etc/httpd-ironic-api.conf.j2
 COPY ironic-config/apache2-vmedia.conf.j2 /etc/httpd-vmedia.conf.j2
+COPY ironic-config/apache2-proxy.conf.j2 /etc/httpd-proxy.conf.j2
 
 RUN mkdir -p /var/lib/ironic /var/lib/ironic-inspector && \
   sqlite3 /var/lib/ironic/ironic.db "pragma journal_mode=wal" && \

--- a/ironic-config/apache2-proxy.conf.j2
+++ b/ironic-config/apache2-proxy.conf.j2
@@ -1,0 +1,31 @@
+<VirtualHost *:{{ env.HTTP_PORT }}>
+    ServerName {{ env.IRONIC_IP }}
+
+    ErrorLog /dev/stderr
+    LogLevel debug
+    CustomLog /dev/stdout combined
+
+    ProxyPass "/"  "{{ env.IRONIC_UPSTREAM_PROTO }}://{{ env.IRONIC_UPSTREAM_IP }}:{{ env.IRONIC_UPSTREAM_PORT }}/"
+    ProxyPassReverse "/"  "{{ env.IRONIC_UPSTREAM_PROTO }}://{{ env.IRONIC_UPSTREAM_IP }}:{{ env.IRONIC_UPSTREAM_PORT }}/"
+    {% if env.IRONIC_UPSTREAM_PROTO == "https" %}
+    SSLProxyEngine On
+
+    {% if env.IRONIC_INSECURE == "true" %}
+    SSLProxyVerify none
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerName off
+    SSLProxyCheckPeerExpire off
+    {% else %}
+    SSLProxyCACertificateFile {{ env.IRONIC_CERT_FILE }}
+    {% endif %}
+
+    {% endif %}
+
+    {% if env.IRONIC_TLS_SETUP == "true" %}
+    SSLEngine on
+    SSLProtocol {{ env.IRONIC_SSL_PROTOCOL }}
+    SSLCertificateFile {{ env.IRONIC_CERT_FILE }}
+    SSLCertificateKeyFile {{ env.IRONIC_KEY_FILE }}
+    {% endif %}
+</VirtualHost>
+

--- a/scripts/runironic-proxy
+++ b/scripts/runironic-proxy
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+. /bin/tls-common.sh
+
+. /bin/ironic-common.sh
+
+wait_for_interface_or_ip
+
+export HTTP_PORT=${HTTP_PORT:-6386}
+export IRONIC_UPSTREAM_IP=${IRONIC_UPSTREAM_IP:-$IRONIC_IP}
+export IRONIC_UPSTREAM_PORT=${IRONIC_UPSTREAM_PORT:-6385}
+export IRONIC_UPSTREAM_PROTO=${IRONIC_UPSTREAM_PROTO:-$IRONIC_SCHEME}
+
+sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
+# Log to std out/err
+sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
+sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+
+render_j2_config /etc/httpd-proxy.conf.j2 /etc/httpd/conf.d/ironic-proxy.conf
+
+exec /usr/sbin/httpd -DFOREGROUND


### PR DESCRIPTION
In OpenShift we deploy Ironic only on one of the controlplane nodes.
When the provisioning network is disabled, IPA talks to Ironic API via
the node's IP address. If the Metal3 pod is relocated, IPA loses contact
to Ironic API.

Upstream in Metal3, this problem is solved via keepalived. We don't want
to introduce another VIP in OpenShift, so instead this change adds
a new script that launches httpd as a proxy to real Ironic. It will be
deployed as a DaemonSet, making Ironic API available on the API VIP.

The cluster-baremetal-operator will be responsible for updating
the DaemonSet with the up-to-date real Ironic IP address.
