### PR TITLE
Revert "Sync with upstream metal3-io ironic-image"

### DIFF
--- a/ironic-inspector-config/inspector-apache.conf.j2
+++ b/ironic-inspector-config/inspector-apache.conf.j2
@@ -12,11 +12,7 @@
 
 
 Listen 5050
-{% if env.LISTEN_ALL_INTERFACES | lower == "true" %}
- <VirtualHost *:5050>
-{% else %}
- <VirtualHost {{ env.IRONIC_URL_HOST }}:5050>
-{% endif %}
+<VirtualHost *:5050>
     ProxyPass "/"  "http://127.0.0.1:{{ env.IRONIC_INSPECTOR_PRIVATE_PORT }}/"
     ProxyPassReverse "/"  "http://127.0.0.1:{{ env.IRONIC_INSPECTOR_PRIVATE_PORT }}/"
 

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -11,8 +11,8 @@ function get_provisioning_interface() {
 
   local interface="provisioning"
   for mac in ${PROVISIONING_MACS//,/ } ; do
-    if ip -br link show up | grep -qi "$mac"; then
-      interface=$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ')
+    if ip -br link show up | grep -q "$mac"; then
+      interface=$(ip -br link show up | grep "$mac" | cut -f 1 -d ' ')
       break
     fi
   done

--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -65,11 +65,7 @@ if [ -n "${INSPECTOR_HTPASSWD:-}" ]; then
     printf "%s\n" "${INSPECTOR_HTPASSWD}" > /etc/ironic-inspector/htpasswd
 fi
 
-if [[ "${LISTEN_ALL_INTERFACES}" == "true" ]]; then
-  sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
-else
-  sed -i 's/^Listen .*$/Listen '"$IRONIC_URL_HOST"':'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
-fi
+sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
 sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
     -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
     -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
Reverts openshift/ironic-image#283, tracked in https://issues.redhat.com/browse/TRT-444

Per [TRT policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get ci and/or nightly payloads flowing again.

We are not sure if this is the breaking change, but for now, I'm going to see if this revert makes the 4.12-nightly payload tests pass in an effort to mitigate 4.12-nightly payload blockage.

cc @elfosardo 