### PR TITLE
ironic-proxy: never validate TLS peer name

### DIFF
--- a/ironic-config/apache2-proxy.conf.j2
+++ b/ironic-config/apache2-proxy.conf.j2
@@ -12,12 +12,13 @@
 
     {% if env.IRONIC_INSECURE == "true" %}
     SSLProxyVerify none
-    SSLProxyCheckPeerCN off
-    SSLProxyCheckPeerName off
     SSLProxyCheckPeerExpire off
     {% else %}
     SSLProxyCACertificateFile {{ env.IRONIC_CERT_FILE }}
+    SSLProxyVerify require
+    SSLProxyCheckPeerExpire on
     {% endif %}
+    SSLProxyCheckPeerName off
 
     {% endif %}
 


### PR DESCRIPTION
The way httpd works, it requires a strict match of CommonName even if IP
addresses are provided in SubjectAltName. This is not a setup we can
support. On the other hand, we can validate the Ironic peer uses
the same TLS certificate as we, so let's do it.
