### PR TITLE
OCPBUGS-2011: Backport improvements to iDRAC steps to OCP 4.11

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -11,9 +11,9 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:20.2.1-0.20220902195023.ab80152.el8
-openstack-ironic-api >= 1:20.2.1-0.20220902195023.ab80152.el8
-openstack-ironic-conductor >= 1:20.2.1-0.20220902195023.ab80152.el8
+openstack-ironic >= 1:20.2.1-0.20221012165024.b44ccf1.el8
+openstack-ironic-api >= 1:20.2.1-0.20221012165024.b44ccf1.el8
+openstack-ironic-conductor >= 1:20.2.1-0.20221012165024.b44ccf1.el8
 openstack-ironic-inspector >= 10.12.1-0.20220513095437.6dd37e5.el8
 python3-debtcollector >= 2.5.0-0.20220509211533.a6b46c5.el8
 python3-dracclient >= 8.0.0-0.20220509201613.9c7499c.el8


### PR DESCRIPTION
This commit backports upstream changes in OpenStack/Ironic which resolve https://issues.redhat.com/browse/OCPBUGS-2011 in OpenShift 4.11:

https://review.opendev.org/c/openstack/ironic/+/859916
https://review.opendev.org/c/openstack/ironic/+/860307