### PR TITLE
OCPBUGS-2992: Don't save OS_ prefixed variables

### DIFF
--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -52,9 +52,9 @@ if [ -f /etc/ironic/ironic.conf ]; then
     cp /etc/ironic/ironic.conf /etc/ironic/ironic.conf_orig
 fi
 
-# oslo.config also supports Config Opts From Environment, log them
-echo '# Options set from Environment variables' | tee /etc/ironic/ironic.extra
-env | grep "^OS_" | tee -a /etc/ironic/ironic.extra
+# oslo.config also supports Config Opts From Environment, log them to stdout
+echo 'Options set from Environment variables'
+env | grep "^OS_" || true
 
 mkdir -p /shared/html
 mkdir -p /shared/ironic_prometheus_exporter


### PR DESCRIPTION
This change stops saving the OS_ prefixed variables to a file but keeps them logged on stdout. The file is not consumed elsewhere, by either this image or Ironic itself. Outputting to a container instance's stdout allows some other log collector to save what may be helpful debugging information about the Oslo configuration, and adding the: `|| true` allows for base images without OS_ unset to cause a non-zero return code with pipefail set.

This is a reworded cherry-pick of [the upstream PR](https://github.com/metal3-io/ironic-image/pull/392).