### PR TITLE
Bug OCPBUGS-4305: Remove RDO distribution configuration (finally fixes #46)

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -22,5 +22,8 @@ chown ironic:ironic /var/log/ironic
 # This file is generated after installing mod_ssl and it affects our configuration
 rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf
 
+# RDO-provided configuration forces creating log files
+rm -f /usr/share/ironic/ironic-dist.conf /etc/ironic-inspector/inspector-dist.conf
+
 dnf clean all
 rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
It forces using /var/log/ironic/ironic.log, which is not necessary in containers and also grows indefinitely since log rotation is not enabled.

(cherry picked from commit 8621a3bcba872767901efca7fe8bd6b888bdea59)