### PR TITLE
OCPBUGS-5068: Configure Ironic iLO driver to use web server

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -222,6 +222,7 @@ kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC
 
 [ilo]
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}
+use_web_server_for_images = true
 
 [irmc]
 kernel_append_params = nofb nomodeset vga=normal ipa-insecure=1 {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }}


### PR DESCRIPTION
Configuring iLO Ironic driver to use web server for hosting images. This resolves an issue where it defaults to swift while running in standalone mode, breaking virtual media provisioning.

(cherry picked from commit a192a75282a1a025f1455ffcdd96ceebf79abd82)