### PR TITLE
OCPBUGS-5136: Adding dosfstools and util-linux tools to ironic-image

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -1,6 +1,7 @@
 coreos-installer
 crudini >= 0.9.3-4.el9
 dnsmasq >= 2.85-3.el9
+dosfstools
 genisoimage
 httpd
 httpd-tools
@@ -53,3 +54,4 @@ python3-tooz >= 3.2.0-0.20221128162335.1a76dd6.el9
 python3-zipp >= 0.5.1-3.el9
 qemu-img
 sqlite
+util-linux


### PR DESCRIPTION
Dosfstools and util-linux provide mkfs and mkfs.vfat binaries which are required for image creation operations performed by iLO driver.

(cherry picked from commit 2327eed04d27fd452c5f3e117f30b31d872f885f)