### PR TITLE
[4.11] Bug OCPBUGS-5404: Adding dosfstools and util-linux tools to ironic-image

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -1,6 +1,7 @@
 coreos-installer
 crudini
 dnsmasq >= 2.79-13.el8_3.1
+dosfstools
 genisoimage
 httpd
 httpd-tools
@@ -52,3 +53,4 @@ python3-tooz >= 2.11.1-0.20220509215238.96f91b9.el8
 python3-zipp >= 0.5.1-3.el8
 qemu-img
 sqlite
+util-linux


### PR DESCRIPTION
Dosfstools and util-linux provide mkfs and mkfs.vfat binaries which are required for image creation operations performed by iLO driver.

(cherry picked from commit 2327eed04d27fd452c5f3e117f30b31d872f885f) (cherry picked from commit 0406cf5126fe6a48add67ef34f570700ae0655b4)