### PR TITLE
Adding dep on python3-werkzeug >= 2.0.3-4

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -51,6 +51,7 @@ python3-stevedore >= 4.1.0-0.20221128161654.9eb8094.el9
 python3-sushy >= 4.4.1-0.20221209121037.9427360.el9
 python3-sushy-oem-idrac >= 5.0.0-0.20221128204359.da9a0e4.el9
 python3-tooz >= 3.2.0-0.20221128162335.1a76dd6.el9
+python3-werkzeug >= 2.0.3-4.el9
 python3-zipp >= 0.5.1-3.el9
 qemu-img
 sqlite


### PR DESCRIPTION
OCPBUGS-7567: CVE-2023-25577 python-werkzeug: high resource usage ...
OCPBUGS-7564: CVE-2023-23934 python-werkzeug: cookie prefixed with =..