### PR TITLE
OCPBUGS-7566: Bump werkzeug 4.12

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -51,6 +51,7 @@ python3-stevedore >= 4.0.0-0.20220811180640.ccd1754.el9
 python3-sushy >= 4.3.4-0.20221213135957.69b014c.el9
 python3-sushy-oem-idrac >= 4.0.0-0.20220802162610.7b75e6e.el9
 python3-tooz >= 3.0.0-0.20220811181909.d145b50.el9
+python3-werkzeug >= 2.0.3-4.el9
 python3-zipp >= 0.5.1-3.el9
 qemu-img
 sqlite


### PR DESCRIPTION
OCPBUGS-7567: CVE-2023-25577 python-werkzeug: high resource usage ...
OCPBUGS-7564: CVE-2023-23934 python-werkzeug: cookie prefixed with =..