### PR TITLE
OCPBUGS-7565: Adding dep on python3-werkzeug >= 2.0.3-4

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -50,6 +50,7 @@ python3-stevedore >= 3.5.0-0.20220509195112.442f157.el8
 python3-sushy >= 4.1.6-0.20221213125412.e06f1c3.el8
 python3-sushy-oem-idrac >= 4.0.0-0.20220324125409.7b75e6e.el8
 python3-tooz >= 2.11.1-0.20220509215238.96f91b9.el8
+python3-werkzeug >= 2.0.3-4.el8
 python3-zipp >= 0.5.1-3.el8
 qemu-img
 sqlite


### PR DESCRIPTION
OCPBUGS-7567: CVE-2023-25577 python-werkzeug: high resource usage ...
OCPBUGS-7564: CVE-2023-23934 python-werkzeug: cookie prefixed with =..