### PR TITLE
OCPBUGS-13699: Add python-flask dependency

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -20,6 +20,7 @@ python3-cinderclient >= 9.1.0-0.20221128151726.730a8c7.el9
 python3-debtcollector >= 2.5.0-0.20221128140303.a6b46c5.el9
 python3-dracclient >= 8.0.0-0.20221128135758.9c7499c.el
 python3-eventlet >= 0.33.1-4.el9
+python3-flask >= 2:2.0.1-4.el9.2
 python3-gunicorn >= 20.0.4-2.el9
 python3-ironic-lib >= 5.4.1-0.20230328130611.6e7574c.el9
 python3-ironic-prometheus-exporter >= 4.2.0-0.20230308192702.e63fb2e.el9


### PR DESCRIPTION
Patched version includes fix for
https://bugzilla.redhat.com/show_bug.cgi?id=2196643