### PR TITLE
OCPBUGS-14132: ironic.conf.j2: Bump min_command_interval to 30 on SCOS

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -167,7 +167,11 @@ use_ipmitool_retries = false
 #    Y = min_command_interval
 # If use_ipmitool_retries is false, then ironic retries X times, with an
 # interval of Y in between each tries.
+{% if env.IS_SCOS == "true" %}
+min_command_interval = 30
+{% else %}
 min_command_interval = 5
+{% endif %}
 command_retry_timeout = 60
 # List of possible cipher suites versions that can be
 # supported by the hardware in case the field `cipher_suite`


### PR DESCRIPTION
Intended as a temporary change, this bumps the min_command_interval to 30 on SCOS.
The infrastructure that the OKD Streams build system is going to be deployed to uses an IPMI proxy which introduces additional latency on that specific infrastructure.
Increase min_command_interval until a faster proxy is used. Only affects OKD/SCOS builds of ironic-image.

/cc @derekhiggins 