### PR TITLE
OCPBUGS-9303: update Ironic to include secure boot fixes

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -12,9 +12,9 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:21.5.0-0.20230918114532.b033fbb.el9
-openstack-ironic-api >= 1:21.5.0-0.20230918114532.b033fbb.el9
-openstack-ironic-conductor >= 1:21.5.0-0.20230918114532.b033fbb.el9
+openstack-ironic >= 1:21.5.0-0.20230926214535.b92cf17.el9
+openstack-ironic-api >= 1:21.5.0-0.20230926214535.b92cf17.el9
+openstack-ironic-conductor >= 1:21.5.0-0.20230926214535.b92cf17.el9
 openstack-ironic-inspector >= 11.5.0-0.20230706175125.193aa0d.el9
 python3-automaton >= 3.1.0-0.20230608140652.a4f7631.el9
 python3-cinderclient >= 9.3.0-0.20230608143053.f7a612e.el9


### PR DESCRIPTION
Ironic sync PR https://github.com/openshift/openstack-ironic/pull/47
