### PR TITLE
OCPBUGS-23072: Use bash process substitution instead of pipe

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -33,7 +33,7 @@ function wait_for_interface_or_ip() {
   then
     # Convert the address using ipcalc which strips out the subnet. For IPv6 addresses, this will give the short-form address
     export IRONIC_IP=$(ipcalc "${PROVISIONING_IP}" | grep "^Address:" | awk '{print $2}')
-    until ip -br addr show | grep -q -F " ${IRONIC_IP}/"; do
+    until grep -F " ${IRONIC_IP}/" <(ip -br addr show); do
       echo "Waiting for ${IRONIC_IP} to be configured on an interface"
       sleep 1
     done


### PR DESCRIPTION
Provides more debugging info and can avoid situation where the pipe hides errors.