### PR TITLE
OCPBUGS-23903: Ironic side of external_http_url (METAL-163) is not wired in correctly

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -12,9 +12,9 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:22.1.1-0.20231103140543.59ad635.el9
-openstack-ironic-api >= 1:22.1.1-0.20231103140543.59ad635.el9
-openstack-ironic-conductor >= 1:22.1.1-0.20231103140543.59ad635.el9
+openstack-ironic >= 1:22.1.1-0.20231127172154.5f58fc9.el9
+openstack-ironic-api >= 1:22.1.1-0.20231127172154.5f58fc9.el9
+openstack-ironic-conductor >= 1:22.1.1-0.20231127172154.5f58fc9.el9
 openstack-ironic-inspector >= 11.5.0-0.20230706175125.193aa0d.el9
 python3-automaton >= 3.1.0-0.20230608140652.a4f7631.el9
 python3-cinderclient >= 9.3.0-0.20230608143053.f7a612e.el9


### PR DESCRIPTION
Ironic side of external_http_url (METAL-163) is not wired in correctly