### PR TITLE
OCPBUGS-23978: Ironic side of external_http_url (METAL-163) is not wired in correctly

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -12,9 +12,9 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:21.3.1-0.20231106145533.e53dc4f.el9
-openstack-ironic-api >= 1:21.3.1-0.20231106145533.e53dc4f.el9
-openstack-ironic-conductor >= 1:21.3.1-0.20231106145533.e53dc4f.el9
+openstack-ironic >= 1:21.3.1-0.20231127115527.da18c92.el9
+openstack-ironic-api >= 1:21.3.1-0.20231127115527.da18c92.el9
+openstack-ironic-conductor >= 1:21.3.1-0.20231127115527.da18c92.el9
 openstack-ironic-inspector = 11.2.0-0.20221128164644.d83454c.el9
 python3-cinderclient >= 9.1.0-0.20221128151726.730a8c7.el9
 python3-debtcollector >= 2.5.0-0.20221128140303.a6b46c5.el9


### PR DESCRIPTION
[4.13] Ironic side of external_http_url ([METAL-163](https://issues.redhat.com//browse/METAL-163)) is not wired in correctly