### PR TITLE
OCPBUGS-23979: Ironic side of external_http_url (METAL-163) is not wired in correctly

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -12,9 +12,9 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:21.0.1-0.20231102125537.9230e57.el9
-openstack-ironic-api >= 1:21.0.1-0.20231102125537.9230e57.el9
-openstack-ironic-conductor >= 1:21.0.1-0.20231102125537.9230e57.el9
+openstack-ironic >= 1:21.0.1-0.20231127115526.95f0324.el9
+openstack-ironic-api >= 1:21.0.1-0.20231127115526.95f0324.el9
+openstack-ironic-conductor >= 1:21.0.1-0.20231127115526.95f0324.el9
 openstack-ironic-inspector >= 11.0.1-0.20221205155952.cd22607.el9
 python3-cinderclient >= 9.0.0-0.20220811172734.2c7d463.el9
 python3-debtcollector >= 2.5.0-0.20220802170047.a6b46c5.el9


### PR DESCRIPTION
Ironic side of external_http_url ([METAL-163](https://issues.redhat.com//browse/METAL-163)) is not wired in correctly