### PR TITLE
METAL-849: Install ironic and ironic-inspector from source

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -8,11 +8,16 @@ RUN prepare-efi.sh redhat
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 
+ENV REMOTE_SOURCES=${REMOTE_SOURCES:-.}
+ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-.}
 ENV PKGS_LIST=main-packages-list.ocp
 ARG EXTRA_PKGS_LIST
 
 COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh prepare-ipxe.sh configure-nonroot.sh /bin/
+
+# some cachito magic
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 
 RUN prepare-image.sh && \
     rm -f /bin/prepare-image.sh && \

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -12,48 +12,56 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-openstack-ironic >= 1:23.1.1-0.20240205131523.c1e46bd.el9
-openstack-ironic-api >= 1:23.1.1-0.20240205131523.c1e46bd.el9
-openstack-ironic-conductor >= 1:23.1.1-0.20240205131523.c1e46bd.el9
-openstack-ironic-inspector >= 11.8.1-0.20240124142446.c544cf2.el9
 python3-automaton >= 3.2.0-0.20231214191506.9255778.el9
 python3-cinderclient >= 9.4.0-0.20231214204912.f1f14df.el9
 python3-cliff >= 4.4.0-0.20240118172647.3ee0725.el9
+python3-construct
 python3-debtcollector >= 2.5.0-0.20231214185855.a6b46c5.el9
 python3-dracclient >= 8.0.0-0.20231214182834.9c7499c.el9
 python3-eventlet >= 0.33.1-5.el9
 python3-flask >= 2:2.0.1-4.el9.2
-python3-futurist >= 2.4.1-0.20231214190050.159d752.el9
+python3-futurist >= 2.4.1-0.20230720141142.159d752.el9
+python3-glanceclient >= 4.4.0-0.20231026133336.62e6fc8.el9
 python3-gunicorn >= 20.0.4-2.el9
-python3-glanceclient >= 4.4.0-0.20231214201927.62e6fc8.el9
-python3-ironic-lib >= 5.6.1-0.20240118194123.d623b86.el9
-python3-ironic-prometheus-exporter >= 4.3.0-0.20231219134422.5211827.el9
+python3-ironic-lib >= 5.5.1-0.20231219150533.14c3782.el9
+python3-ironic-prometheus-exporter >= 4.3.0-0.20231002134531.b3e0de8.el9
 python3-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
 python3-jinja2 >= 2-3.0.1-2.el9.1
-python3-keystoneauth1 >= 5.4.0-0.20240118173157.44e477d.el9
+python3-jsonpath-rw
+python3-jsonschema >= 4.0.0
+python3-keystoneauth1 >= 5.3.0-0.20231026134545.e6f3999.el9
+python3-keystonemiddleware >= 10.4.1-0.20231214203310.d36c86c.el9
 python3-markupsafe >= 2.1.1-4.el9
 python3-mod_wsgi
 python3-msgpack >= 0.6.2-2.el9
-python3-openstacksdk >= 2.0.0-0.20231218182038.8f6a2cf.el9
-python3-oslo-cache >= 3.5.0-0.20231218171752.06f76e5.el9
-python3-oslo-concurrency >= 5.2.0-0.20231218170305.1abc8e0.el9
-python3-oslo-config >= 9.2.0-0.20231218170403.28187da.el9
-python3-oslo-context >= 5.3.0-0.20240118173150.8d25cad.el9
-python3-oslo-db >= 14.1.0-0.20231218180946.caebf76.el9
-python3-oslo-i18n >= 6.2.0-0.20240118173758.4bcda78.el9
-python3-oslo-log >= 5.4.0-0.20240118172027.b5b8c30.el9
+python3-netaddr >= 0.9.0-2.el9
+python3-openstacksdk >= 1.2.0-0.20230720175432.b7ff031.el9
+python3-os-traits >= 3.0.0-0.20231218162158.cff125c.el9
+python3-oslo-cache >= 3.5.0-0.20231026131556.06f76e5.el9
+python3-oslo-concurrency >= 5.2.0-0.20231026130849.1abc8e0.el9
+python3-oslo-config >= 9.2.0-0.20231026131249.28187da.el9
+python3-oslo-context >= 5.1.1-0.20230720150313.7696282.el9
+python3-oslo-db >= 14.1.0-0.20231026141011.caebf76.el9
+python3-oslo-i18n >= 6.0.0-0.20230720141652.03605c2.el9
+python3-oslo-log >= 5.2.0-0.20230720153530.16a8a42.el9
 python3-oslo-messaging >= 14.3.1-0.20230608152013.0602d1a.el9
-python3-oslo-middleware >= 5.2.0-0.20231218180517.4ba32ed.el9
-python3-oslo-policy >= 4.2.1-0.20231218165109.37de6f3.el9
-python3-oslo-serialization >= 5.2.0-0.20231218173202.a0ba2d7.el9
-python3-oslo-service >= 3.2.0-0.20231218171804.e94d47a.el9
-python3-oslo-utils >= 6.3.0-0.20240118174515.505d80e.el9
-python3-oslo-versionedobjects >= 3.2.0-0.20231218174336.6478669.el9
+python3-oslo-middleware >= 5.2.0-0.20231026140101.4ba32ed.el9
+python3-oslo-policy >= 4.2.1-0.20231026130744.37de6f3.el9
+python3-oslo-rootwrap >= 7.1.0-0.20231218164901.0660a66.el9
+python3-oslo-serialization >= 5.2.0-0.20231026132830.a0ba2d7.el9
+python3-oslo-service >= 3.2.0-0.20231026132024.e94d47a.el9
+python3-oslo-upgradecheck >= 2.2.0-0.20231218163225.cbee52e.el9
+python3-oslo-utils >= 6.2.1-0.20231026132331.a5941e8.el9
+python3-oslo-versionedobjects >= 3.2.0-0.20231026133739.6478669.el9
+python3-osprofiler >= 4.1.0-0.20231214195221.3c5fead.el9
 python3-packaging >= 20.4-2.el9
 python3-paste >= 3.5.0-3.el9.1
 python3-paste-deploy >= 2.0.1-5.el9
+python3-pecan
 python3-pint >= 0.10.1-3.el9
 python3-proliantutils >= 2.16.0-0.20231026140721.5839129.el9
+python3-psutil
+python3-pycdlib
 python3-pyghmi >= 1.5.14-2.1.el9ost
 python3-scciclient >= 0.12.3-0.20230308201513.0940a71.el9
 python3-stevedore >= 5.1.0-0.20231218163929.2d99ccc.el9

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -18,6 +18,49 @@ if [[ -n "${EXTRA_PKGS_LIST:-}" ]]; then
     fi
 fi
 
+### cachito magic works for OCP only
+if  [[ -f /tmp/main-packages-list.ocp ]]; then
+
+    REQS="${REMOTE_SOURCES_DIR}/requirements.cachito"
+
+    ls -la "${REMOTE_SOURCES_DIR}/" # DEBUG
+
+    # load cachito variables only if they're available
+    if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
+        source "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env"
+        REQS="${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/requirements.cachito"
+    fi
+
+    ### source install ###
+    BUILD_DEPS="python3-devel gcc gcc-c++"
+
+    dnf install -y python3-pip python3-setuptools $BUILD_DEPS
+
+    # NOTE(elfosardo): --no-index is used to install the packages emulating
+    # an isolated environment in CI. Do not use the option for downstream
+    # builds.
+    PIP_OPTIONS=""
+    if [[ ! -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
+        PIP_OPTIONS="--no-index"
+    fi
+    python3 -m pip install $PIP_OPTIONS --prefix /usr -r "${REQS}"
+
+    # ironic and ironic-inspector system configuration
+    mkdir -p /var/log/ironic /var/log/ironic-inspector /var/lib/ironic /var/lib/ironic-inspector
+    getent group ironic >/dev/null || groupadd -r ironic
+    getent passwd ironic >/dev/null || useradd -r -g ironic -s /sbin/nologin ironic -d /var/lib/ironic
+    getent group ironic-inspector >/dev/null || groupadd -r ironic-inspector
+    getent passwd ironic-inspector >/dev/null || useradd -r -g ironic-inspector -s /sbin/nologin ironic-inspector -d /var/lib/ironic-inspector
+
+    dnf remove -y $BUILD_DEPS
+
+    if [[ -d "${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps" ]]; then
+        rm -rf $REMOTE_SOURCES_DIR
+    fi
+
+fi
+###
+
 chown ironic:ironic /var/log/ironic
 # This file is generated after installing mod_ssl and it affects our configuration
 rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/*.conf

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,0 +1,2 @@
+ironic @ git+https://github.com/openshift/openstack-ironic@1c35a03e7f7a5327f965ed2afac4e478aad1ed53
+ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@4d300358409742e531ec503d3af0a0fd06849a01


### PR DESCRIPTION
Stop using RPMs for ironic and ironic-inspector and install all their services from source code directly, using the openshift forks.