### PR TITLE
METAL-949: Force pysnmp-lextudio and pyasn1 min version

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -60,11 +60,14 @@ python3-paste >= 3.5.0-3.el9.1
 python3-paste-deploy >= 2.0.1-5.el9
 python3-pecan
 python3-pint >= 0.10.1-3.el9
-python3-proliantutils >= 2.16.0-0.20231026140721.5839129.el9
+python3-proliantutils >= 2.16.2-0.20240325141527.f655e23.el9
 python3-psutil
+python3-pyasn1 >= 0.5.1-3.el9
 python3-pycdlib
 python3-pyghmi >= 1.5.14-2.1.el9ost
-python3-scciclient >= 0.12.3-0.20230308201513.0940a71.el9
+python3-pysnmp-lextudio >= 5.0.26-2.el9
+python3-scciclient >= 0.16.0-0.20240325141527.73b4e3d.el9
+python3-smi-lextudio >= 1.1.13-0.1.el9
 python3-stevedore >= 5.1.0-0.20231218163929.2d99ccc.el9
 python3-sushy-oem-idrac >= 5.0.0-0.20231218155726.da9a0e4.el9
 python3-tooz >= 4.2.0-0.20231214201931.bed303e.el9


### PR DESCRIPTION
Recently lextudio dropped pyasn1 so we want to be explicit and show that we install pysnmp-lextudio but normal pyasn1.