### PR TITLE
TRT-1637: Revert #473 "NO-ISSUE: Merge from metal3-io/ironic-image "

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ functionality:
   use `IRONIC_EXTERNAL_IP` if available.
 - `IRONIC_INSPECTOR_CALLBACK_ENDPOINT_OVERRIDE` - Override Inspector's callback
   URL. Defaults to use `IRONIC_EXTERNAL_IP` if available.
-- `IRONIC_ENABLE_VLAN_INTERFACES` - Which VLAN interfaces to enable on the
-  agent start-up. Can be a list of interfaces or a special value `all`.
-  Defaults to `all`.
 
 The ironic configuration can be overridden by various environment variables.
 The following can serve as an example:

--- a/configure-nonroot.sh
+++ b/configure-nonroot.sh
@@ -44,9 +44,4 @@ chmod 2775 /var/lib/dnsmasq
 touch /var/lib/dnsmasq/dnsmasq.leases
 chmod 664 /etc/dnsmasq.conf /var/lib/dnsmasq/dnsmasq.leases
 
-# probes that are created before start
-touch /bin/ironic-{readi,live}ness
-chown root:"${IRONIC_GROUP}" /bin/ironic-{readi,live}ness
-chmod 775 /bin/ironic-{readi,live}ness
-
 setcap "cap_net_raw,cap_net_admin,cap_net_bind_service=+eip" /usr/sbin/dnsmasq

--- a/ironic-config/httpd-ironic-api.conf.j2
+++ b/ironic-config/httpd-ironic-api.conf.j2
@@ -19,6 +19,8 @@ Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
  <VirtualHost {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}>
 {% endif %}
 
+    {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
+
     {% if env.IRONIC_PRIVATE_PORT == "unix" %}
     ProxyPass "/"  "unix:/shared/ironic.sock|http://127.0.0.1/"
     ProxyPassReverse "/"  "unix:/shared/ironic.sock|http://127.0.0.1/"
@@ -27,8 +29,14 @@ Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
     ProxyPassReverse "/"  "http://127.0.0.1:{{ env.IRONIC_PRIVATE_PORT }}/"
     {% endif %}
 
+    {% else %}
+    WSGIDaemonProcess ironic user=ironic group=ironic threads=10 display-name=%{GROUP}
+    WSGIScriptAlias / /usr/bin/ironic-api-wsgi
+    {% endif %}
+
     SetEnv APACHE_RUN_USER ironic
     SetEnv APACHE_RUN_GROUP ironic
+    WSGIProcessGroup ironic
 
     ErrorLog /dev/stderr
     LogLevel debug
@@ -41,6 +49,7 @@ Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
     SSLCertificateKeyFile {{ env.IRONIC_KEY_FILE }}
 {% endif %}
 
+    {% if env.IRONIC_REVERSE_PROXY_SETUP | lower == "true" %}
     <Location />
          {% if "IRONIC_HTPASSWD" in env and env.IRONIC_HTPASSWD | length %}
             AuthType Basic
@@ -49,6 +58,22 @@ Listen {{ env.IRONIC_URL_HOST }}:{{ env.IRONIC_LISTEN_PORT }}
             Require valid-user
          {% endif %}
     </Location>
+    {% else %}
+    <Directory /usr/bin >
+        WSGIProcessGroup ironic
+        WSGIApplicationGroup %{GLOBAL}
+        AllowOverride None
+
+        {% if "IRONIC_HTPASSWD" in env and env.IRONIC_HTPASSWD | length %}
+        AuthType Basic
+        AuthName "Restricted WSGI area"
+        AuthUserFile "/etc/ironic/htpasswd"
+        Require valid-user
+        {% else %}
+        Require all granted
+        {% endif %}
+    </Directory>
+    {% endif %}
 
     <Location ~ "^/(v1/?)?$" >
         Require all granted

--- a/ironic-config/httpd-modules.conf
+++ b/ironic-config/httpd-modules.conf
@@ -5,6 +5,7 @@ LoadModule dir_module modules/mod_dir.so
 LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule unixd_module modules/mod_unixd.so
 LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule wsgi_module modules/mod_wsgi_python3.so
 LoadModule ssl_module modules/mod_ssl.so
 LoadModule env_module modules/mod_env.so
 LoadModule proxy_module modules/mod_proxy.so

--- a/ironic-config/inspector.ipxe.j2
+++ b/ironic-config/inspector.ipxe.j2
@@ -5,6 +5,6 @@ echo In inspector.ipxe
 imgfree
 # NOTE(dtantsur): keep inspection kernel params in [mdns]params in
 # ironic-inspector-image and configuration in configure-ironic.sh
-kernel --timeout 60000 http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/images/ironic-python-agent.kernel ipa-insecure=1 ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {{ env.INSPECTOR_EXTRA_ARGS }} initrd=ironic-python-agent.initramfs {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} || goto retry_boot
+kernel --timeout 60000 http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/images/ironic-python-agent.kernel ipa-insecure=1 ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 {{ env.INSPECTOR_EXTRA_ARGS }} initrd=ironic-python-agent.initramfs {% if env.IRONIC_RAMDISK_SSH_KEY %}sshkey="{{ env.IRONIC_RAMDISK_SSH_KEY|trim }}"{% endif %} {{ env.IRONIC_KERNEL_PARAMS|trim }} || goto retry_boot
 initrd --timeout 60000 http://{{ env.IRONIC_URL_HOST }}:{{ env.HTTP_PORT }}/images/ironic-python-agent.initramfs || goto retry_boot
 boot

--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -9,17 +9,17 @@ debug = true
 default_deploy_interface = direct
 default_inspect_interface = {% if env.USE_IRONIC_INSPECTOR == "true" %}inspector{% else %}agent{% endif %}
 default_network_interface = noop
-enabled_bios_interfaces = no-bios,redfish,idrac-redfish,irmc,ilo
+enabled_bios_interfaces = idrac-wsman,no-bios,redfish,idrac-redfish,irmc,ilo
 enabled_boot_interfaces = ipxe,ilo-ipxe,pxe,ilo-pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,ilo-virtual-media
 enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.
 enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish,manual-management,ilo,ilo5
-enabled_inspect_interfaces = {% if env.USE_IRONIC_INSPECTOR == "true" %}inspector{% else %}agent{% endif %},irmc,fake,redfish,ilo
-enabled_management_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
-enabled_power_interfaces = ipmitool,irmc,fake,redfish,idrac-redfish,ilo
-enabled_raid_interfaces = no-raid,irmc,agent,fake,redfish,idrac-redfish,ilo5
-enabled_vendor_interfaces = no-vendor,ipmitool,idrac-redfish,redfish,ilo,fake
+enabled_inspect_interfaces = {% if env.USE_IRONIC_INSPECTOR == "true" %}inspector{% else %}agent{% endif %},idrac-wsman,irmc,fake,redfish,ilo
+enabled_management_interfaces = ipmitool,idrac-wsman,irmc,fake,redfish,idrac-redfish,ilo,ilo5,noop
+enabled_power_interfaces = ipmitool,idrac-wsman,irmc,fake,redfish,idrac-redfish,ilo
+enabled_raid_interfaces = no-raid,irmc,agent,fake,idrac-wsman,redfish,idrac-redfish,ilo5
+enabled_vendor_interfaces = no-vendor,ipmitool,idrac-wsman,idrac-redfish,redfish,ilo,fake
 enabled_firmware_interfaces = no-firmware,fake,redfish
 {% if env.IRONIC_EXPOSE_JSON_RPC | lower == "true" %}
 rpc_transport = json-rpc
@@ -30,7 +30,14 @@ use_stderr = true
 # NOTE(dtantsur): the default md5 is not compatible with FIPS mode
 hash_ring_algorithm = sha256
 my_ip = {{ env.IRONIC_IP }}
+{% if env.IRONIC_DEPLOYMENT == "Conductor" and env.JSON_RPC_AUTH_STRATEGY == "noauth" %}
+# if access is unauthenticated, we bind only to localhost - use that as the
+# host name also, so that the client can find the server
+# If we run both API and conductor in the same pod, use localhost
+host = localhost
+{% else %}
 host = {{ env.IRONIC_CONDUCTOR_HOST }}
+{% endif %}
 
 # If a path to a certificate is defined, use that first for webserver
 {% if env.WEBSERVER_CACERT_FILE %}
@@ -145,7 +152,7 @@ power_off = {{ false if env.IRONIC_FAST_TRACK == "true" else true }}
 # NOTE(dtantsur): keep inspection arguments synchronized with inspector.ipxe
 # Also keep in mind that only parameters unique for inspection go here.
 # No need to duplicate pxe_append_params/kernel_append_params.
-extra_kernel_params = ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} ipa-enable-vlan-interfaces={{ env.IRONIC_ENABLE_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1
+extra_kernel_params = ipa-inspection-collectors={{ env.IRONIC_IPA_COLLECTORS }} ipa-enable-vlan-interfaces={{ env.IRONIC_INSPECTOR_VLAN_INTERFACES }} ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1
 
 {% if env.USE_IRONIC_INSPECTOR == "true" %}
 endpoint_override = {{ env.IRONIC_INSPECTOR_BASE_URL }}
@@ -161,10 +168,6 @@ hooks = $default_hooks,parse-lldp
 add_ports = all
 keep_ports = present
 {% endif %}
-
-[auto_discovery]
-enabled = {{ env.IRONIC_INSPECTOR_ENABLE_DISCOVERY }}
-driver = ipmi
 
 [ipmi]
 # use_ipmitool_retries transfers the responsibility of retrying to ipmitool
@@ -197,9 +200,15 @@ cipher_suite_versions = 3,17
 # authentication over localhost, using the same credentials as API, to prevent
 # unauthenticated connections from other processes in the same host since the
 # containers are in host networking.
-auth_strategy = http_basic
+auth_strategy = {{ env.JSON_RPC_AUTH_STRATEGY }}
 http_basic_auth_user_file = /etc/ironic/htpasswd-rpc
+{% if env.IRONIC_DEPLOYMENT == "Conductor" and env.JSON_RPC_AUTH_STRATEGY == "noauth" %}
+# if access is unauthenticated, we bind only to localhost - use that as the
+# host name also, so that the client can find the server
+host_ip = localhost
+{% else %}
 host_ip = {% if env.LISTEN_ALL_INTERFACES | lower == "true" %}::{% else %}{{ env.IRONIC_IP }}{% endif %}
+{% endif %}
 {% if env.IRONIC_TLS_SETUP == "true" %}
 use_ssl = true
 cafile = {{ env.IRONIC_CACERT_FILE }}

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -17,6 +17,7 @@ python3-cinderclient >= 9.4.0-0.20231214204912.f1f14df.el9
 python3-cliff >= 4.5.0-0.20240219142400.156e1eb.el9
 python3-construct
 python3-debtcollector >= 2.5.0-0.20231214185855.a6b46c5.el9
+python3-dracclient >= 8.0.0-0.20231214182834.9c7499c.el9
 python3-eventlet >= 0.33.1-6.el9
 python3-flask >= 2:2.0.1-4.el9.2
 python3-futurist >= 2.4.1-0.20230720141142.159d752.el9
@@ -30,6 +31,7 @@ python3-keystoneclient >= 5.3.0-0.20240219143223.83dfa1e.el9
 python3-keystonemiddleware >= 10.4.1-0.20231214203310.d36c86c.el9
 python3-markupsafe >= 2.1.1-4.el9
 python3-microversion-parse >= 1.0.1-0.20240424173932.2c36df6.el9
+python3-mod_wsgi
 python3-msgpack >= 0.6.2-2.el9
 python3-netaddr >= 0.9.0-2.el9
 python3-openstacksdk >= 2.1.0-0.20240219143936.ed4117f.el9

--- a/main-packages-list.okd
+++ b/main-packages-list.okd
@@ -20,6 +20,7 @@ python3-automaton
 python3-cinderclient
 python3-cliff
 python3-debtcollector
+python3-dracclient
 python3-eventlet
 python3-flask
 python3-futurist
@@ -29,6 +30,7 @@ python3-ironicclient
 python3-jinja2
 python3-keystoneauth1
 python3-markupsafe
+python3-mod_wsgi
 python3-msgpack
 python3-openstacksdk
 python3-oslo-cache

--- a/scripts/auth-common.sh
+++ b/scripts/auth-common.sh
@@ -2,64 +2,36 @@
 
 set -euxo pipefail
 
+export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
+export IRONIC_DEPLOYMENT="${IRONIC_DEPLOYMENT:-}"
 export IRONIC_REVERSE_PROXY_SETUP=${IRONIC_REVERSE_PROXY_SETUP:-false}
 export INSPECTOR_REVERSE_PROXY_SETUP=${INSPECTOR_REVERSE_PROXY_SETUP:-false}
 
-# Backward compatibility
-if [[ "${IRONIC_DEPLOYMENT:-}" == "Conductor" ]]; then
-    export IRONIC_EXPOSE_JSON_RPC=true
-else
-    export IRONIC_EXPOSE_JSON_RPC="${IRONIC_EXPOSE_JSON_RPC:-false}"
-fi
-
-set +x
 IRONIC_HTPASSWD_FILE=/etc/ironic/htpasswd
-if [[ -f "/auth/ironic/username" ]]; then
-    IRONIC_HTPASSWD_USERNAME=$(</auth/ironic/username)
-fi
-IRONIC_HTPASSWD_USERNAME=${IRONIC_HTPASSWD_USERNAME:-}
-if [[ -f "/auth/ironic/password" ]]; then
-    IRONIC_HTPASSWD_PASSWORD=$(</auth/ironic/password)
-fi
-IRONIC_HTPASSWD_PASSWORD=${IRONIC_HTPASSWD_PASSWORD:-}
-if [[ -n "${IRONIC_HTPASSWD_USERNAME}" ]]; then
-    IRONIC_HTPASSWD="$(htpasswd -n -b -B "${IRONIC_HTPASSWD_USERNAME}" "${IRONIC_HTPASSWD_PASSWORD}")"
-fi
-export IRONIC_HTPASSWD=${IRONIC_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
-
 INSPECTOR_HTPASSWD_FILE=/etc/ironic-inspector/htpasswd
-if [[ -f "/auth/inspector/username" ]]; then
-    read -r INSPECTOR_HTPASSWD_USERNAME<"/auth/inspector/username"
-fi
-INSPECTOR_HTPASSWD_USERNAME=${INSPECTOR_HTPASSWD_USERNAME:-}
-if [[ -f "/auth/inspector/password" ]]; then
-    read -r INSPECTOR_HTPASSWD_PASSWORD<"/auth/inspector/password"
-fi
-INSPECTOR_HTPASSWD_PASSWORD=${INSPECTOR_HTPASSWD_PASSWORD:-}
-if [[ -n "${INSPECTOR_HTPASSWD_USERNAME}" ]]; then
-    INSPECTOR_HTPASSWD="$(htpasswd -n -b -B "${INSPECTOR_HTPASSWD_USERNAME}" "${INSPECTOR_HTPASSWD_PASSWORD}")"
-fi
-export INSPECTOR_HTPASSWD=${INSPECTOR_HTPASSWD:-${HTTP_BASIC_HTPASSWD:-}}
-set -x
 
 configure_client_basic_auth()
 {
     local auth_config_file="/auth/$1/auth-config"
     local dest="${2:-/etc/ironic/ironic.conf}"
     if [[ -f "${auth_config_file}" ]]; then
-        # Merge configurations in the "auth" directory into the default ironic configuration file
+        # Merge configurations in the "auth" directory into the default ironic configuration file because there is no way to choose the configuration file
+        # when running the api as a WSGI app.
         crudini --merge "${dest}" < "${auth_config_file}"
     fi
 }
 
 configure_json_rpc_auth()
 {
-    if [[ "${IRONIC_EXPOSE_JSON_RPC}" == "true" ]]; then
-        if [[ -z "${IRONIC_HTPASSWD}" ]]; then
-            echo "FATAL: enabling JSON RPC requires authentication"
-            exit 1
+    export JSON_RPC_AUTH_STRATEGY="noauth"
+    if [[ -n "${IRONIC_HTPASSWD}" ]]; then
+        if [[ "${IRONIC_DEPLOYMENT}" == "Conductor" ]]; then
+            export JSON_RPC_AUTH_STRATEGY="http_basic"
+            printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}-rpc"
+        else
+            printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}"
         fi
-        printf "%s\n" "${IRONIC_HTPASSWD}" > "${IRONIC_HTPASSWD_FILE}-rpc"
     fi
 }
 

--- a/scripts/configure-ironic.sh
+++ b/scripts/configure-ironic.sh
@@ -2,13 +2,14 @@
 
 set -euxo pipefail
 
+IRONIC_DEPLOYMENT="${IRONIC_DEPLOYMENT:-}"
 IRONIC_EXTERNAL_IP="${IRONIC_EXTERNAL_IP:-}"
 
 # Define the VLAN interfaces to be included in introspection report, e.g.
 #   all - all VLANs on all interfaces using LLDP information
 #   <interface> - all VLANs on a particular interface using LLDP information
 #   <interface.vlan> - a particular VLAN on an interface, not relying on LLDP
-export IRONIC_ENABLE_VLAN_INTERFACES=${IRONIC_ENABLE_VLAN_INTERFACES:-${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}}
+export IRONIC_INSPECTOR_VLAN_INTERFACES=${IRONIC_INSPECTOR_VLAN_INTERFACES:-all}
 
 # shellcheck disable=SC1091
 . /bin/tls-common.sh
@@ -37,6 +38,7 @@ fi
 export NUMWORKERS=${NUMWORKERS:-$NUMPROC}
 
 export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-true}
+export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-true}
 
 # Whether to enable fast_track provisioning or not
 export IRONIC_FAST_TRACK=${IRONIC_FAST_TRACK:-true}
@@ -100,20 +102,3 @@ configure_client_basic_auth ironic-rpc
 
 # Make sure ironic traffic bypasses any proxies
 export NO_PROXY="${NO_PROXY:-},$IRONIC_IP"
-
-PROBE_CURL_ARGS=
-if [[ "${IRONIC_REVERSE_PROXY_SETUP}" == "true" ]]; then
-    if [[ "${IRONIC_PRIVATE_PORT}" == "unix" ]]; then
-        PROBE_URL="http://127.0.0.1:6385"
-        PROBE_CURL_ARGS="--unix-socket /shared/ironic.sock"
-    else
-        PROBE_URL="http://127.0.0.1:${IRONIC_PRIVATE_PORT}"
-    fi
-else
-        PROBE_URL="${IRONIC_BASE_URL}"
-fi
-export PROBE_CURL_ARGS
-export PROBE_URL
-
-PROBE_KIND=readiness render_j2_config /bin/ironic-probe.j2 /bin/ironic-readiness
-PROBE_KIND=liveness render_j2_config /bin/ironic-probe.j2 /bin/ironic-liveness

--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -103,5 +103,9 @@ export IRONIC_INSPECTOR_ACCESS_PORT=${IRONIC_INSPECTOR_ACCESS_PORT:-5050}
 export IRONIC_INSPECTOR_LISTEN_PORT=${IRONIC_INSPECTOR_LISTEN_PORT:-$IRONIC_INSPECTOR_ACCESS_PORT}
 
 # If this is false, built-in inspection is used.
-export USE_IRONIC_INSPECTOR=${USE_IRONIC_INSPECTOR:-false}
+export USE_IRONIC_INSPECTOR=${USE_IRONIC_INSPECTOR:-true}
 export IRONIC_INSPECTOR_ENABLE_DISCOVERY=${IRONIC_INSPECTOR_ENABLE_DISCOVERY:-false}
+if [[ "${USE_IRONIC_INSPECTOR}" != "true" ]] && [[ "${IRONIC_INSPECTOR_ENABLE_DISCOVERY}" == "true" ]]; then
+    echo "Discovery is only supported with ironic-inspector at this point"
+    exit 1
+fi

--- a/scripts/ironic-probe.j2
+++ b/scripts/ironic-probe.j2
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -eu -o pipefail
-
-curl -sSf {{ env.PROBE_CURL_ARGS }} "{{ env.PROBE_URL }}"
-
-# TODO(dtantsur): when PROBE_KIND==readiness, try the conductor and driver API
-# to make sure the conductor is ready. This requires having access to secrets
-# since these endpoints are authenticated.

--- a/scripts/runironic-api
+++ b/scripts/runironic-api
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+export IRONIC_DEPLOYMENT="API"
+
+# shellcheck disable=SC1091
+. /bin/configure-ironic.sh
+
+export IRONIC_REVERSE_PROXY_SETUP=false
+
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < /tmp/httpd-ironic-api.conf.j2 > /etc/httpd/conf.d/ironic.conf
+
+# shellcheck disable=SC1091
+. /bin/runhttpd

--- a/scripts/runironic-conductor
+++ b/scripts/runironic-conductor
@@ -1,9 +1,6 @@
 #!/usr/bin/bash
 
-# These settings must go before configure-ironic since it has different
-# defaults.
-export IRONIC_USE_MARIADB=${IRONIC_USE_MARIADB:-false}
-export IRONIC_EXPOSE_JSON_RPC=${IRONIC_EXPOSE_JSON_RPC:-false}
+export IRONIC_DEPLOYMENT="Conductor"
 
 # shellcheck disable=SC1091
 . /bin/configure-ironic.sh
@@ -20,6 +17,4 @@ if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UP
     done &
 fi
 
-configure_ironic_auth
-
-exec /usr/bin/ironic
+exec /usr/bin/ironic-conductor


### PR DESCRIPTION

Reverts #473 ; tracked by [TRT-1637](https://issues.redhat.com//browse/TRT-1637)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Test revert only, we don't know if this is our issue yet, but some metal jobs now are losing apiserver during install.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.16-e2e-metal-ipi-ovn-ipv6
```

CC: @MahnoorAsghar

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
