### PR TITLE
METAL-1049: Download and install sources from local dir

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -2,3 +2,5 @@ ironic @ git+https://github.com/openshift/openstack-ironic@1e15afd063fc7cdce1c50
 ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@323caaf82d8be1370a25b294eef6ba10be45baef
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@e3eaf180bae38004979bfe339c0be0f65396cbf1
 sushy @ git+https://github.com/openshift/openstack-sushy@9da48cbc8802e5febf33440b3e5a0e86747a2eef
+
+# DEPENDENCIES


### PR DESCRIPTION
Since in CI we use the --no-index option to emulate a pip disconnected environment to try and reproduce the downstream build conditions, it's not possible to test normal dependencies from source as pip won't be able to retrieve them from any remote source.
To work around that we download all the packages first removing the --no-index option but using the --no-deps option, preventing downloading dependencies.
This forces to download only the packages specified in the requirements file, ensuring total control on main libraries and dependencies and allowing us to be as granular as needed, easily switching between RPMs and source packages for testing or even for downstream builds.
When we install them afterwards if any dependency is missing the installation process will fail in CI, allowing us to correct the dependencies list directly the change PR.

Downloading the libraries first and then installing them with the same option allows more flexibility and almost a 1-to-1 copy of the downstream build environment that cachito uses.