### PR TITLE
OCPBUGS-32261: Update ironic-inspector to fix the memory leak

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
 ironic @ git+https://github.com/openshift/openstack-ironic@1e15afd063fc7cdce1c503417a9a9a28b550c711
-ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@323caaf82d8be1370a25b294eef6ba10be45baef
+ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@c8cfd9a6c4b477d6effb7506280a954885dec0ba
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@e3eaf180bae38004979bfe339c0be0f65396cbf1
 sushy @ git+https://github.com/openshift/openstack-sushy@9da48cbc8802e5febf33440b3e5a0e86747a2eef


### PR DESCRIPTION
See https://review.opendev.org/c/openstack/ironic-inspector/+/921875
