### PR TITLE
OCPBUGS-34898: Fix for python-jinja2

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -23,7 +23,7 @@ python3-eventlet >= 0.33.1-5.el9
 python3-flask >= 2:2.0.1-4.el9.2
 python3-ironic-lib >= 5.4.1-0.20230410165532.b393f4c.el9
 python3-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
-python3-jinja2 >= 2-3.0.1-2.el9.1
+python3-jinja2 >= 2-3.0.1-3.el9.1
 python3-keystoneauth1 >= 5.0.0-0.20221128144522.2445a5d.el9
 python3-mod_wsgi
 python3-msgpack >= 0.6.2-2.el9


### PR DESCRIPTION
Tagged the package from https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3155347 