### PR TITLE
METAL-1123: Suppress file listing of compiled py files

### DIFF
--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -64,7 +64,7 @@ if  [[ -f /tmp/main-packages-list.ocp ]]; then
 
     # NOTE(janders) since we set --no-compile at install time, we need to
     # compile post-install (see RHEL-29028)
-    python3 -m compileall --invalidation-mode=timestamp /usr
+    python3 -m compileall --invalidation-mode=timestamp -q /usr
 
     # ironic system configuration
     mkdir -p /var/log/ironic /var/lib/ironic


### PR DESCRIPTION
Suppress the listing of files and directories being compiled/searched. compileall will still output any errors but they will no longer get lost in the 3000+ lines of output.