### PR TITLE
OCPBUGS-43959, OCPBUGS-43951: Bump python-waitress

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -68,6 +68,7 @@ python3-smi-lextudio >= 1.1.13-0.1.el9
 python3-stevedore >= 5.3.0-0.20240926155155.51134a4.el9
 python3-sushy-oem-idrac >= 5.0.1-0.20240522171520.4e51aef.el9
 python3-tooz >= 6.3.0-0.20240926164120.734acc4.el9
+python3-waitress >= 3.0.1-1.el9
 python3-webob >= 1.8.8-2.el9
 python3-werkzeug >= 2.2.3-3.el9
 python3-zeroconf >= 0.24.4-2.el9


### PR DESCRIPTION
Bumping python-waitress to 3.0.1