### PR TITLE
[4.16] OCPBUGS-48151,OCPBUGS-48598: Bump jinja2 to 3.0.1-6.el9.2

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -20,7 +20,7 @@ python3-eventlet >= 0.33.1-6.el9
 python3-flask >= 2:2.0.1-4.el9.2
 python3-futurist >= 2.4.1-0.20230720141142.159d752.el9
 python3-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
-python3-jinja2 >= 3.0.1-3.el9.1
+python3-jinja2 >= 3.0.1-6.el9.2
 python3-jsonpath-rw
 python3-jsonschema >= 4.0.0
 python3-keystoneauth1 >= 5.5.0-0.20240219144549.733a34b.el9


### PR DESCRIPTION
This includes the fix for CVE available in 3.1.5