### PR TITLE
[4.14] OCPBUGS-48147,OCPBUGS-48594: Bump jinja2 to 3.0.1-6.el9.2

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -23,7 +23,7 @@ python3-flask >= 2:2.0.1-4.el9.2
 python3-futurist >= 2.4.1-0.20230308173923.159d752.el9
 python3-glanceclient >= 4.3.0-0.20230608143056.52fb6b2.el9
 python3-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
-python3-jinja2 >= 3.0.1-3.el9.1
+python3-jinja2 >= 3.0.1-6.el9.2
 python3-jsonpath-rw
 python3-keystoneauth1 >= 5.2.0-0.20230608152518.2e40bbf.el9
 python3-keystonemiddleware


### PR DESCRIPTION
This includes the fix for CVE available in 3.1.5