### PR TITLE
[4.12] OCPBUGS-48145,OCPBUGS-48596: Bump jinja to 3.0.1-6.el9.2

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -23,7 +23,7 @@ python3-eventlet >= 0.30.2-4.el9
 python3-flask >= 1:2.0.1-3.el9
 python3-ironic-lib >= 5.2.0-0.20220802170917.e205816.el9
 python3-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
-python3-jinja2 >= 3.0.1-3.el9.1
+python3-jinja2 >= 3.0.1-6.el9.2
 python3-keystoneauth1 >= 5.0.0-0.20220811173415.2445a5d.el9
 python3-mod_wsgi
 python3-msgpack >= 0.6.2-2.el9


### PR DESCRIPTION
This includes the fix for both CVEs available in 3.1.5