### PR TITLE
OCPBUGS-49755: Use pynotify instead of inotify-tools

### DIFF
--- a/scripts/runhttpd
+++ b/scripts/runhttpd
@@ -75,18 +75,18 @@ fi
 
 # Set up inotify to kill the container (restart) whenever cert files for ironic api change
 if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    # shellcheck disable=SC2034
-    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read -r file event; do
-        kill -WINCH $(pgrep httpd)
-    done &
+    python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_CERT_FILE}" |
+        while read -r file event; do
+            kill -WINCH $(pgrep httpd)
+        done &
 fi
 
 # Set up inotify to kill the container (restart) whenever cert of httpd for /shared/html/<redifsh;ilo> path change
 if [[ "$IRONIC_VMEDIA_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    # shellcheck disable=SC2034
-    inotifywait -m -e delete_self "${IRONIC_VMEDIA_CERT_FILE}" | while read -r file event; do
-        kill -WINCH $(pgrep httpd)
-    done &
+    python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_VMEDIA_CERT_FILE}" |
+        while read -r file event; do
+            kill -WINCH $(pgrep httpd)
+        done &
 fi
 
 exec /usr/sbin/httpd -DFOREGROUND

--- a/scripts/runironic
+++ b/scripts/runironic
@@ -12,10 +12,10 @@ mkdir -p /shared/log/ironic/deploy
 run_ironic_dbsync
 
 if [[ "$IRONIC_TLS_SETUP" == "true" ]] && [[ "${RESTART_CONTAINER_CERTIFICATE_UPDATED}" == "true" ]]; then
-    # shellcheck disable=SC2034
-    inotifywait -m -e delete_self "${IRONIC_CERT_FILE}" | while read -r file event; do
-        kill $(pgrep ironic)
-    done &
+    python3 -m pyinotify -e IN_DELETE_SELF -v "${IRONIC_CERT_FILE}" |
+        while read -r file event; do
+            kill $(pgrep ironic)
+        done &
 fi
 
 configure_ironic_auth

--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -3,16 +3,9 @@
 # Ramdisk logs path
 LOG_DIR="/shared/log/ironic/deploy"
 
-while :; do
-    if ! ls "${LOG_DIR}"/*.tar.gz 1> /dev/null 2>&1; then
-        continue
-    fi
-
-    for fn in "${LOG_DIR}"/*.tar.gz; do
-        echo "************ Contents of $fn ramdisk log file bundle **************"
-        tar -xOzvvf "$fn" | sed -e "s/^/$(basename "$fn"): /"
-        rm -f "$fn"
+python3 -m pyinotify -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
+    while read -r path _action file; do
+        echo "************ Contents of ${path}/${file} ramdisk log file bundle **************"
+        tar -xOzvvf "${path}/${file}" | sed -e "s/^/${file}: /"
+        rm -f "${path}/${file}"
     done
-
-    sleep 5
-done


### PR DESCRIPTION
The inotify-tools last release is from september 2023 and last update in the repo is 7 months old (May 2024). The inotify-tools package is not present in the EPEL10 repo anymore while python3-inotify is in a native repository. This change allows us to remove dependency from EPEL entirely.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
(cherry picked from commit 9f700307f469632da9d7f7940eeeb479235fd0b6)