### PR TITLE
OCPBUGS-49829: Fix runlogwatch failure if LOG_DIR does not exist

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -3,6 +3,8 @@
 # Ramdisk logs path
 LOG_DIR="/shared/log/ironic/deploy"
 
+mkdir -p "${LOG_DIR}"
+
 python3 -m pyinotify -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
     while read -r path _action file; do
         echo "************ Contents of ${path}/${file} ramdisk log file bundle **************"


### PR DESCRIPTION
Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
(cherry picked from commit dc60eca6b6189d619d909fbecfb75a124655c81d)