### PR TITLE
OCPBUGS-50613: Install python3-inotify pkg explicitly

### DIFF
--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -21,6 +21,7 @@ python3-debtcollector >= 3.0.0-0.20240522153257.0e6ce1c.el9
 python3-eventlet >= 0.33.1-6.el9
 python3-flask >= 2:2.0.1-4.el9.2
 python3-futurist >= 3.0.0-0.20240522153313.4e14db5.el9
+python3-inotify
 python3-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
 python3-jinja2 >= 3.1.5-1.el9
 python3-jsonpath-rw

--- a/main-packages-list.okd
+++ b/main-packages-list.okd
@@ -24,6 +24,7 @@ python3-eventlet
 python3-flask
 python3-futurist
 python3-glanceclient
+python3-inotify
 python3-ironic-lib
 python3-ironicclient
 python3-jinja2


### PR DESCRIPTION
The python3-inotify package is installed as dependency but it should be explicitly mentioned in the packages list to avoid issues like https://github.com/okd-project/okd/issues/2113