### PR TITLE
OCPBUGS-51310: Fix runlogwatch script

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -5,9 +5,13 @@ LOG_DIR="/shared/log/ironic/deploy"
 
 mkdir -p "${LOG_DIR}"
 
-python3 -m pyinotify -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
-    while read -r path _action file; do
-        echo "************ Contents of ${path}/${file} ramdisk log file bundle **************"
-        tar -xOzvvf "${path}/${file}" | sed -e "s/^/${file}: /"
-        rm -f "${path}/${file}"
+# shellcheck disable=SC2034
+python3 -m pyinotify --raw-format -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
+    while read -r event dir mask maskname filename filepath pathname wd; do
+        #NOTE(elfosardo): a pyinotify event looks like this:
+        # <Event dir=False mask=0x8 maskname=IN_CLOSE_WRITE name=mylogs.gzip path=/shared/log/ironic/deploy pathname=/shared/log/ironic/deploy/mylogs.gzip wd=1 >
+        FILENAME=$(echo "${filename}" | cut -d'=' -f2-)
+        echo "************ Contents of ${LOG_DIR}/${FILENAME} ramdisk log file bundle **************"
+        tar -xOzvvf "${LOG_DIR}/${FILENAME}" | sed -e "s/^/${FILENAME}: /"
+        rm -f "${LOG_DIR}/${FILENAME}"
     done


### PR DESCRIPTION
Use correct values for read command, and remove colors from output.
a pyinotify event looks like this:
<Event dir=False mask=0x8 maskname=IN_CLOSE_WRITE name=mylogs.gzip path=/shared/log/ironic/deploy pathname=/shared/log/ironic/deploy/mylogs.gzip wd=1 > by default the output contains colorize text that is interpreted literally by variable conversion in the tar command, so not only we have to parse it, but
we also need to get just raw format output.

Signed-off-by: Riccardo Pittau <elfosardo@gmail.com>
(cherry picked from commit 9e2d94ae3e6fd487ed0b59d24e68e0c1c81f16ce)