### PR TITLE
METAL-1299: Do not use openstack packages

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -4,6 +4,7 @@ FROM registry.ci.openshift.org/ocp/4.19:base-rhel9 AS builder
 WORKDIR /tmp
 
 COPY prepare-efi.sh /bin/
+RUN dnf config-manager --disable rhel-9-openstack-17-rpms || true
 RUN prepare-efi.sh redhat
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
@@ -19,7 +20,8 @@ COPY prepare-image.sh prepare-ipxe.sh configure-nonroot.sh /bin/
 # some cachito magic
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"
 
-RUN prepare-image.sh && \
+RUN dnf config-manager --disable rhel-9-openstack-17-rpms  || true && \
+    prepare-image.sh && \
     rm -f /bin/prepare-image.sh && \
     /bin/prepare-ipxe.sh && \
     rm -f /tmp/prepare-ipxe.sh


### PR DESCRIPTION
They conflict with our owns and we don't use them in production so the builds are completely different between CI and production actually making the tests completely unreliable.