### PR TITLE
METAL-1306: Do not use openstack packages

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -4,6 +4,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16 AS builder
 WORKDIR /tmp
 
 COPY prepare-efi.sh /bin/
+RUN dnf config-manager --disable rhel-9-openstack-17-rpms || true
 RUN prepare-efi.sh redhat
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
@@ -19,7 +20,8 @@ COPY prepare-image.sh prepare-ipxe.sh configure-nonroot.sh /bin/
 # some cachito magic
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"
 
-RUN prepare-image.sh && \
+RUN dnf config-manager --disable rhel-9-openstack-17-rpms  || true && \
+    prepare-image.sh && \
     rm -f /bin/prepare-image.sh && \
     /bin/prepare-ipxe.sh && \
     rm -f /tmp/prepare-ipxe.sh


### PR DESCRIPTION
They conflict with our owns and we don't use them in production so the builds are completely different between CI and production actually making the tests completely unreliable.

(cherry picked from commit 434c33e21fa1ac887471c90d60de8af14a0a42b5)