### PR TITLE
OCPBUGS-55381: Extract files one-by-one in logwatch

### DIFF
--- a/scripts/runlogwatch.sh
+++ b/scripts/runlogwatch.sh
@@ -12,6 +12,10 @@ python3 -m pyinotify --raw-format -e IN_CLOSE_WRITE -v "${LOG_DIR}" |
         # <Event dir=False mask=0x8 maskname=IN_CLOSE_WRITE name=mylogs.gzip path=/shared/log/ironic/deploy pathname=/shared/log/ironic/deploy/mylogs.gzip wd=1 >
         FILENAME=$(echo "${filename}" | cut -d'=' -f2-)
         echo "************ Contents of ${LOG_DIR}/${FILENAME} ramdisk log file bundle **************"
-        tar -xOzvvf "${LOG_DIR}/${FILENAME}" | sed -e "s/^/${FILENAME}: /"
+        tar -tzf "${LOG_DIR}/${FILENAME}" | while read -r entry; do
+            echo "${FILENAME}: **** Entry: ${entry} ****"
+            tar -xOzf "${LOG_DIR}/${FILENAME}" "${entry}" | sed -e "s/^/${FILENAME}: /"
+            echo
+        done
         rm -f "${LOG_DIR}/${FILENAME}"
     done


### PR DESCRIPTION
Currently, there is what seems to be a buffering problem: the file names
sometimes do not come before the content but rather at the end of a
random line. In an attempt to fix it, I'm switching from extracting all
files to listing files and extracting them one by one.

I'm also adding extra new lines to make the output more readable.

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
