### PR TITLE
METAL-1528: Use custom directories in the runironic-proxy script

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -36,6 +36,7 @@ COPY ironic-config/ironic.conf.j2 /etc/ironic/
 
 # Custom httpd config, removes all but the bare minimum needed modules
 COPY ironic-config/httpd.conf.j2 /etc/httpd/conf/
+COPY ironic-config/httpd-ironic-proxy.conf.j2 /etc/httpd/conf/
 COPY ironic-config/httpd-modules.conf /etc/httpd/conf.modules.d/
 COPY ironic-config/apache2-vmedia.conf.j2 /templates/httpd-vmedia.conf.j2
 COPY ironic-config/apache2-proxy.conf.j2 /etc/httpd-proxy.conf.j2

--- a/ironic-config/httpd-ironic-proxy.conf.j2
+++ b/ironic-config/httpd-ironic-proxy.conf.j2
@@ -1,0 +1,49 @@
+ServerRoot {{ env.HTTPD_DIR }}
+Listen [::]:{{ env.IRONIC_PROXY_PORT }}
+Include /etc/httpd/conf.modules.d/*.conf
+User apache
+Group apache
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+ErrorLog "/dev/stderr"
+
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+    <IfModule logio_module>
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+    CustomLog "/dev/stderr" combined
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig /etc/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+    AddType text/html .shtml
+    AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+AddDefaultCharset UTF-8
+
+<IfModule mime_magic_module>
+    MIMEMagicFile conf/magic
+</IfModule>
+
+PidFile {{ env.IRONIC_TMP_DATA_DIR }}/httpd.pid
+
+# http TRACE can be subjected to abuse and should be disabled
+TraceEnable off
+
+# provide minimal server information
+ServerTokens Prod
+ServerSignature Off
+
+IncludeOptional conf.d/*.conf
+

--- a/scripts/runironic-proxy
+++ b/scripts/runironic-proxy
@@ -15,11 +15,14 @@ if [[ "$IRONIC_UPSTREAM_IP" =~ .*:.* ]]; then
     export IRONIC_UPSTREAM_IP="[$IRONIC_UPSTREAM_IP]"
 fi
 
-sed -i 's/^Listen .*$/Listen [::]:'"$IRONIC_PROXY_PORT"'/' "${HTTPD_CONF_DIR}/httpd.conf"
-# Log to std out/err
-sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' "${HTTPD_CONF_DIR}/httpd.conf"
-sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' "${HTTPD_CONF_DIR}/httpd.conf"
+if [[ -f "${HTTPD_CONF_DIR}/httpd.conf" ]]; then
+    mv "${HTTPD_CONF_DIR}/httpd.conf" "${HTTPD_CONF_DIR}/httpd.conf.example"
+fi
+
+# Render the core httpd config
+render_j2_config "/etc/httpd/conf/httpd-ironic-proxy.conf.j2" \
+    "${HTTPD_CONF_DIR}/httpd.conf"
 
 render_j2_config /etc/httpd-proxy.conf.j2 "${HTTPD_CONF_DIR_D}/ironic-proxy.conf"
 
-exec /usr/sbin/httpd -DFOREGROUND
+exec /usr/sbin/httpd -DFOREGROUND -f "${HTTPD_CONF_DIR}/httpd.conf"


### PR DESCRIPTION
Use custom directories in runironic-proxy and add a httpd config template for the proxy since we don't need the document root and other fields to run a proxy.