### PR TITLE
WIP Fixes the OKD/scos/fcos image and python3.12

### DIFF
--- a/Dockerfile.fcos
+++ b/Dockerfile.fcos
@@ -12,7 +12,7 @@ ENV PKGS_LIST=main-packages-list.okd
 ARG EXTRA_PKGS_LIST
 
 COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} /tmp/
-COPY prepare-image.sh prepare-ipxe.sh configure-nonroot.sh /bin/
+COPY prepare-image.sh prepare-ipxe.sh configure-nonroot.sh scripts/* /bin/
 
 # Configure OpenStack repos
 RUN sed -E -i 's/( =.*| >=.*)//g' /tmp/${PKGS_LIST} && \
@@ -23,8 +23,6 @@ RUN prepare-image.sh && \
     rm -f /bin/prepare-image.sh && \
     /bin/prepare-ipxe.sh && \
     rm -f /tmp/prepare-ipxe.sh
-
-COPY scripts/* /bin/
 
 # IRONIC #
 COPY --from=builder /tmp/esp.img /tmp/uefi_esp.img

--- a/main-packages-list.okd
+++ b/main-packages-list.okd
@@ -16,6 +16,7 @@ openstack-ironic
 openstack-ironic-api
 openstack-ironic-conductor
 openstack-ironic-inspector
+python3.12
 python3-automaton
 python3-cinderclient
 python3-cliff


### PR DESCRIPTION
Fixes #675 by adding Python 3.12 to the list of packages installed for OKD with scos and fcos. There was another issue in the Dockerfile.fcos preventing it from building, `prepare-image` was called before it was copied in.