### PR TITLE
Update hardcoded python3.12 version to more generic python3

### DIFF
--- a/scripts/ironic-common.sh
+++ b/scripts/ironic-common.sh
@@ -117,7 +117,7 @@ wait_for_interface_or_ip()
 
 render_j2_config()
 {
-    python3.12 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < "$1" > "$2"
+    python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' < "$1" > "$2"
 }
 
 run_ironic_dbsync()


### PR DESCRIPTION
Upstream builds on SCOS 9 for ironic-proxy images, they only have python3.9 now. Rebasing the image to SCOS 10 would (presumably) solve he problem, but a more immediate fix is to just not require specific python version here, to make same code run under SCOS 9 and SCOS 10.