### PR TITLE
[4.20] OCPBUGS-52427: Bump ironic and sushy to fix idrac10

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,5 +1,5 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@f477baf4a7cf0253bbccc6e4c6a27dabe2cc5a81
-sushy @ git+https://github.com/openshift/openstack-sushy@d707777f8cd61c82100957e428aa0f5f0286ff41
+ironic @ git+https://github.com/openshift/openstack-ironic@6562023e42a9fdc9300e2eea0d5a01615a0e2059
+sushy @ git+https://github.com/openshift/openstack-sushy@618e1f05507c5ee2ce917117dc5e0b98eb4d2399
 
 proliantutils===2.16.3
 python-scciclient===0.17.0


### PR DESCRIPTION
This commit aims to update the hash of ironic and sushy, the latest commit have the fixes for idrac10