### PR TITLE
METAL-1878: [s2i] Move direct dependencies from packages to source

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -20,7 +20,7 @@ COPY build-packages-list.ocp /tmp/
 RUN set -euxo pipefail && \
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
     echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
-    xargs -rtd'\n' dnf install -y < /tmp/build-packages-list.ocp
+    grep -v '^#' /tmp/build-packages-list.ocp | xargs -rtd'\n' dnf install -y
 
 # Copy cachito sources
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"

--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -1,10 +1,26 @@
+# C/C++ compilers for building Python C extensions (psutil, greenlet, etc.)
 gcc
 gcc-c++
+# needed by pip to fetch packages from git URLs
 git-core
+# Python headers for building C extensions
 python3.12-devel
-python3.12-packaging >= 24.2
+# build backends required by various packages in requirements.cachito
+python3.12-flit-core
+python3.12-hatch-fancy-pypi-readme
+python3.12-hatch-vcs
+python3.12-hatchling >= 1.21.1-1.1.el9ocp
+python3.12-packaging >= 24.2-1.el9ocp
+# used by most OpenStack packages as their build system
 python3.12-pbr
+python3.12-poetry-core
+# pip and wheel for downloading and building wheels
 python3.12-pip
 python3.12-setuptools >= 78.1.1
+# needed by bcrypt 4.x to compile its Rust-based _bcrypt extension
+python3.12-setuptools-rust
 python3.12-setuptools_scm
+# test dependencies pulled in by some OpenStack packages at build time
+python3.12-testresources >= 2.0.1
+python3.12-testscenarios >= 0.5.0
 python3.12-wheel

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -12,74 +12,52 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-python3.12-automaton >= 3.2.0-0.20250214184705.9255778.el9
 python3.12-babel >= 2.9.1-2.el9
 python3.12-certifi >= 2020.12.5-2.1.el9
 python3.12-charset-normalizer
-python3.12-cheroot >= 10.0.1-5.el9
 python3.12-cliff >= 4.9.1
-python3.12-construct
-python3.12-cotyledon >= 2.0.0-1
 python3.12-debtcollector >= 3.0.0-0.20250214185317.0e6ce1c.el9
 python3.12-defusedxml >= 0.7.1-1.el9
 python3.12-eventlet >= 0.40.1-1.el9ocp
 python3.12-flask >= 1:2.2.5-3.1.el9ocp
-python3.12-futurist >= 3.2.1
 python3.12-gunicorn >= 20.0.4-4.1.el9ocp
+python3.12-hatch-fancy-pypi-readme
+python3.12-hatch-vcs
+python3.12-hatchling >= 1.21.1-1.1.el9ocp
 python3.12-inotify >= 0.9.6-26.el9ocp
 python3.12-ironic-prometheus-exporter >= 4.7.0-1.el9ocp
-python3.12-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
+python3.12-iso8601 >= 2.1.0-1.el9ocp
 python3.12-jinja2 >= 3.1.6-1.el9
 python3.12-jsonpath-rw
-python3.12-jsonschema >= 4.0.0
+python3.12-jsonschema-specifications >= 2023.12.1-1.el9ocp
+python3.12-pyjwt >= 2.4.0-1.el9ocp
 python3.12-keyring >= 25.6.0
-python3.12-keystoneauth1 >= 5.10.0
-python3.12-keystoneclient >= 5.6.0
-python3.12-keystonemiddleware >= 10.9.0
-python3.12-lark >= 1.2.2
 python3.12-markupsafe >= 2.1.1-4.el9
 python3.12-microversion-parse >= 1.0.1-0.20240424173932.2c36df6.el9
 python3.12-msgpack >= 0.6.2-2.el9
 python3.12-netaddr >= 0.10.1-2.el9
-python3.12-openstacksdk >= 4.4.0
-python3.12-os-traits >= 3.3.0
 python3.12-osc-lib >= 3.2.0
-python3.12-oslo-cache >= 3.10.1
-python3.12-oslo-concurrency >= 7.1.0
-python3.12-oslo-config >= 9.7.1
-python3.12-oslo-context >= 5.7.1
-python3.12-oslo-db >= 17.2.1
-python3.12-oslo-i18n >= 6.5.1
-python3.12-oslo-log >= 7.1.0
-python3.12-oslo-messaging >= 16.1.0
-python3.12-oslo-metrics >= 0.11.0
-python3.12-oslo-middleware >= 6.3.1
-python3.12-oslo-policy >= 4.5.1
-python3.12-oslo-serialization >= 5.7.0
-python3.12-oslo-service >= 4.3.0
-python3.12-oslo-upgradecheck >= 2.5.0
-python3.12-oslo-utils >= 8.2.0
-python3.12-oslo-versionedobjects >= 3.6.0
+python3.12-oslo-cache >= 3.12.0-1.el9ocp
 python3.12-osprofiler >= 4.2.0-0.20250214190140.3fb0487.el9
 python3.12-packaging >= 20.4-2.el9
 python3.12-paste >= 3.5.0-3.el9.1
 python3.12-paste-deploy >= 2.0.1-5.el9
-python3.12-pbr >= 6.0.0-1.el9
 python3.12-pecan
 python3.12-pint >= 0.10.1-3.el9
 python3.12-psutil
 python3.12-pyasn1 >= 0.5.1-3.el9
 python3.12-pyasn1-modules >= 0.5.1-3.el9
+python3.12-pycadf
 python3.12-pycdlib
 python3.12-pyghmi >= 1.5.14-2.1.el9ost
 python3.12-pysnmp-lextudio >= 5.0.33-1.el9
-python3.12-requests >= 2.32.3-2.el9
 python3.12-retrying
 python3.12-setproctitle >= 1.3.7-1
 python3.12-smi-lextudio >= 1.1.13-0.1.el9
-python3.12-stevedore >= 5.4.1
-python3.12-tooz >= 6.3.0-0.20240926164120.734acc4.el9
+python3.12-testresources >= 2.0.1
+python3.12-testscenarios >= 0.5.0
 python3.12-typing-extensions >= 4.12.2-2.el9
+python3.12-voluptuous >= 0.11.7-3.1.el9ocp
 python3.12-waitress >= 3.0.1-1.el9
 python3.12-webob >= 1.8.8-2.el9
 python3.12-websockify >= 0.9.0

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -11,88 +11,78 @@ ipxe-bootimgs-aarch64
 ipxe-bootimgs-x86
 ipxe-roms-qemu
 mod_ssl
-python3.12-automaton >= 3.2.0-0.20250214184705.9255778.el9
+python3.12-amqp >= 2.5.2
+python3.12-attrs >= 22.2.0
 python3.12-babel >= 2.9.1-2.el9
+python3.12-cachetools >= 2.0.0
 python3.12-certifi >= 2020.12.5-2.1.el9
 python3.12-charset-normalizer
-python3.12-cheroot >= 10.0.1-5.el9
 python3.12-cliff >= 4.9.1
-python3.12-construct
-python3.12-cotyledon >= 2.0.0-1
+python3.12-dateutil >= 2.7.0
 python3.12-debtcollector >= 3.0.0-0.20250214185317.0e6ce1c.el9
+python3.12-decorator >= 4.0.0
 python3.12-defusedxml >= 0.7.1-1.el9
 python3.12-etcd3gw >= 2.3.0
 python3.12-eventlet >= 0.40.3-2.el9ocp
+python3.12-fasteners >= 0.7.0
 python3.12-flask >= 1:2.2.5-3.1.el9ocp
-python3.12-flexcache >= 0.3-3.el9ocp
-python3.12-flexparser >= 0.4-1.el9ocp
-python3.12-futurist >= 3.2.1
+python3.12-greenlet >= 0.4.15
 python3.12-gunicorn >= 20.0.4-4.1.el9ocp
 python3.12-inotify >= 0.9.6-26.el9ocp
-python3.12-ironic-prometheus-exporter >= 4.7.0-1.el9ocp
-python3.12-ironicclient >= 4.9.0-0.20211209154934.6f1be06.el9
-python3.12-jinja2 >= 3.1.6-1.el9
+python3.12-invoke >= 2.0
+python3.12-iso8601 >= 2.1.0-1.el9ocp
+python3.12-jaraco-functools
+python3.12-jmespath >= 0.9.0
 python3.12-jsonpath-rw
-python3.12-jsonschema >= 4.0.0
+python3.12-jsonpointer >= 1.9
+python3.12-jsonschema-specifications >= 2023.12.1-1.el9ocp
 python3.12-keyring >= 25.6.0
-python3.12-keystoneauth1 >= 5.10.0
-python3.12-keystoneclient >= 5.6.0
-python3.12-keystonemiddleware >= 10.9.0-0.20260216145500.557d173
-python3.12-lark >= 1.2.2
+python3.12-kombu >= 4.6.6
+python3.12-lxml >= 3.3.0
+python3.12-mako
 python3.12-markupsafe >= 2.1.1-4.el9
-python3.12-microversion-parse >= 1.0.1-0.20240424173932.2c36df6.el9
+python3.12-more-itertools >= 2.6
 python3.12-msgpack >= 0.6.2-2.el9
-python3.12-netaddr >= 0.10.1-2.el9
-python3.12-netmiko >= 4.7.0-1.el9ocp
-python3.12-neutron-lib >= 4.1.0
-python3.12-openstacksdk >= 4.9.0
-python3.12-os-traits >= 3.3.0
-python3.12-osc-lib >= 3.2.0
-python3.12-oslo-cache >= 3.10.1
-python3.12-oslo-concurrency >= 7.1.0
-python3.12-oslo-config >= 9.7.1
-python3.12-oslo-context >= 5.7.1
-python3.12-oslo-db >= 17.2.1
-python3.12-oslo-i18n >= 6.5.1
-python3.12-oslo-log >= 7.1.0
-python3.12-oslo-messaging >= 16.1.0
-python3.12-oslo-metrics >= 0.11.0
-python3.12-oslo-middleware >= 6.3.1
-python3.12-oslo-policy >= 4.5.1
-python3.12-oslo-serialization >= 5.7.0
-python3.12-oslo-service >= 4.3.0
-python3.12-oslo-upgradecheck >= 2.5.0
-python3.12-oslo-utils >= 8.2.0
-python3.12-oslo-versionedobjects >= 3.6.0
-python3.12-osprofiler >= 4.2.0-0.20250214190140.3fb0487.el9
-python3.12-packaging >= 24.2-1.el9ocp
-python3.12-paramiko >= 4.0.0-1.el9ocp
+python3.12-numpy
+python3.12-openvswitch >= 2.8.0
+python3.12-oslo-i18n >= 3.15.3
+python3.12-packaging >= 20.4
 python3.12-paste >= 3.5.0-3.el9.1
 python3.12-paste-deploy >= 2.0.1-5.el9
-python3.12-pbr >= 6.0.0-1.el9
-python3.12-pecan
 python3.12-pint >= 0.24.4-2.el9ocp
-python3.12-psutil
+python3.12-platformdirs >= 3
+python3.12-prettytable >= 0.7.2
 python3.12-pyasn1 >= 0.5.1-5.el9ocp
 python3.12-pyasn1-modules >= 0.5.1-5.el9ocp
-python3.12-pycdlib
 python3.12-pyghmi >= 1.5.14-2.1.el9ost
+python3.12-pyjwt >= 2.4.0-1.el9ocp
+python3.12-pynacl >= 1.5
+python3.12-pyOpenSSL >= 19.1.0
+python3.12-pyparsing >= 2.1.0
+python3.12-pyserial >= 3.3
 python3.12-pyroute2 >= 0.7.3
 python3.12-pysnmp-lextudio >= 5.0.33-1.el9
-python3.12-pyyaml >= 6.0.2-2.el9ocp
-python3.12-requests >= 2.32.3-2.el9
+python3.12-redis
+python3.12-referencing >= 0.28.4
+python3.12-rich >= 13.8
+python3.12-requestsexceptions >= 1.2.0
 python3.12-retrying
+python3.12-routes >= 2.3.1
+python3.12-ruamel-yaml >= 0.17
+python3.12-rpds-py >= 0.7.1
 python3.12-setproctitle >= 1.3.7-1
+python3.12-six >= 1.9.0
 python3.12-smi-lextudio >= 1.1.13-0.1.el9
-python3.12-stevedore >= 5.4.1
-python3.12-tooz >= 6.3.0-0.20240926164120.734acc4.el9
+python3.12-statsd >= 3.2.1
+python3.12-testresources >= 2.0.1
+python3.12-textfsm >= 1.1.3
+python3.12-testscenarios >= 0.5.0
 python3.12-typing-extensions >= 4.12.2-2.el9
+python3.12-voluptuous >= 0.11.7-3.1.el9ocp
 python3.12-waitress >= 3.0.1-1.el9
 python3.12-watchdog
-python3.12-webob >= 1.8.8-2.el9
-python3.12-websockify >= 0.9.0
 python3.12-werkzeug >= 2.2.3-3.el9
-python3.12-zeroconf >= 0.24.4-2.el9
+python3.12-yappi >= 1.0
 python3.12-zipp >= 3.19.1-1.el9
 qemu-img
 sqlite

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -8,14 +8,14 @@ echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
 
 dnf upgrade -y
 
-xargs -rtd'\n' dnf install -y < /tmp/${PKGS_LIST}
+grep -v '^#' "/tmp/${PKGS_LIST}" | xargs -rtd'\n' dnf install -y
 if [ $(uname -m) = "x86_64" ]; then
     dnf install -y syslinux-nonlinux;
 fi
 
 if [[ -n "${EXTRA_PKGS_LIST:-}" ]]; then
     if [[ -s "/tmp/${EXTRA_PKGS_LIST}" ]]; then
-        xargs -rtd'\n' dnf install -y < /tmp/"${EXTRA_PKGS_LIST}"
+        grep -v '^#' "/tmp/${EXTRA_PKGS_LIST}" | xargs -rtd'\n' dnf install -y
     fi
 fi
 

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,7 +1,48 @@
 ironic @ git+https://github.com/openshift/openstack-ironic@67041b9d76138242904831794c97d8412bcbe6fb
 sushy @ git+https://github.com/openshift/openstack-sushy@645958fda87b06137c7394ef9e36ca38cc7c575c
 
+# HARDWARE DRIVERS DEPENDENCIES
 proliantutils===2.16.3
 python-scciclient===0.17.0
 
-# DEPENDENCIES
+# DIRECT DEPENDENCIES
+alembic===1.14.0
+automaton===3.3.0
+bcrypt===4.3.0
+cheroot===11.0.0
+construct===2.10.70
+cotyledon===2.0.0
+futurist===3.2.1
+jsonpatch===1.33
+jsonschema===4.19.2
+keystoneauth1===5.12.0
+keystonemiddleware===10.12.0
+lark===1.3.0
+openstacksdk===4.8.0
+os-service-types===1.8.0
+os-traits===3.5.0
+oslo.concurrency===7.2.0
+oslo.config===10.1.0
+oslo.db===17.4.0
+oslo.log===7.2.1
+oslo.messaging===17.1.0
+oslo.middleware===7.0.0
+oslo.policy===4.7.0
+oslo.serialization===5.8.0
+oslo.service===4.4.1
+oslo.upgradecheck===2.6.0
+oslo.utils===9.2.0
+oslo.versionedobjects===3.8.0
+pbr===7.0.3
+requests===2.32.5
+SQLAlchemy===2.0.44
+stevedore===5.6.0
+tenacity===9.1.2
+tooz===6.3.0
+
+# TRANSITIVE DEPENDENCIES
+# This list should be kept as small as possible
+dogpile.cache===1.3.3
+python-ironicclient===5.14.0
+python-keystoneclient===5.7.0
+tzdata===2025.2

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -12,10 +12,81 @@
 # Cachito build pipeline, so revert before submitting a PR.
 
 ironic @ git+https://github.com/openshift/openstack-ironic@893fb5ff41fca109225d7589eb3358d612cda5cb
+ironic-prometheus-exporter @ git+https://github.com/openshift/openstack-ironic-prometheus-exporter@f8101c983aa2b78fd460ae6e0cadc50e2954c5d8
 sushy @ git+https://github.com/openshift/openstack-sushy@13acced61644ab5a2ff88eff498cd599d16fde42
 networking-generic-switch @ git+https://github.com/openshift/openstack-networking-generic-switch@fe3cd8ff8ed2d08757942b925a927a2619d63189
 
+# HARDWARE DRIVERS DEPENDENCIES
 proliantutils===2.16.3
 python-scciclient===0.17.0
 
-# DEPENDENCIES
+# DIRECT DEPENDENCIES
+alembic===1.14.0
+automaton===3.3.0
+bcrypt===4.3.0
+cheroot===11.0.0
+construct===2.10.70
+cotyledon===2.0.0
+futurist===3.2.1
+Jinja2===3.1.6
+jsonpatch===1.33
+jsonschema===4.19.2
+keystoneauth1===5.12.0
+keystonemiddleware===10.12.0
+lark===1.3.0
+microversion_parse===2.1.0
+netaddr===1.3.0
+netmiko===4.7.0
+neutron-lib===4.1.0
+openstacksdk===4.9.0
+os-ken===4.2.1
+os-service-types===1.8.1
+os-traits===3.5.0
+oslo.cache===3.12.0
+oslo.concurrency===7.2.0
+oslo.config===10.1.0
+oslo.context===6.4.0
+oslo.db===17.4.0
+oslo.log===7.2.1
+oslo.messaging===17.1.0
+oslo.metrics===0.11.0
+oslo.middleware===7.0.0
+oslo.policy===4.7.0
+oslo.serialization===5.8.0
+oslo.service===4.4.1
+oslo.upgradecheck===2.6.0
+oslo.utils===9.2.0
+oslo.versionedobjects===3.10.2
+osprofiler===4.4.0
+paramiko===4.0.0
+pbr===7.0.3
+pecan===1.8.0
+prometheus_client===0.22.1
+pycadf===4.0.1
+psutil===7.2.2
+pycdlib===1.16.0
+PyYAML===6.0.3
+requests===2.32.5
+rfc3986===2.0.0
+SQLAlchemy===2.0.44
+stevedore===5.6.0
+tenacity===9.1.2
+tooz===6.3.0
+WebOb===1.8.10
+websockify===0.13.0
+zeroconf===0.147.1
+
+# TRANSITIVE DEPENDENCIES
+# This list should be kept as small as possible
+dogpile.cache===1.3.3
+idna===3.10
+ifaddr===0.2.0
+jwcrypto===1.5.8
+ncclient===0.6.15
+ntc-templates===6.1.0
+osc-lib===3.2.0
+scp===0.15.0
+python-ironicclient===5.14.0
+python-keystoneclient===5.7.0
+tzdata===2025.2
+urllib3===2.3.0


### PR DESCRIPTION
This is to simplify packages management.
In the long run it will help a lot when switching Python version and base distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependency Updates**
  * Streamlined the Python 3.12 runtime dependency set by reducing a larger collection to a smaller subset while retaining key shared/support libraries.
  * Reorganized requirements into clearly separated, fully pinned sections for direct and transitive packages.
  * Added/updated several pinned libraries (including iso8601, jsonschema specifications, and pyjwt) and raised the minimum for oslo-cache to `>= 3.12.0`.

* **Build & Test Dependencies**
  * Expanded Python 3.12 build tooling with additional helpers (including Hatch, flit-core, poetry-core, and test utilities like testresources/testscenarios).
  * Refined OCP-specific version constraints for build packages (e.g., hatchling and packaging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->