### PR TITLE
OCPBUGS-74406: Update sushy to include DGX B200 credentials fix

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,5 +1,5 @@
 ironic @ git+https://github.com/openshift/openstack-ironic@205cab3f891da48480377faf1f596c22e9bf82ea
-sushy @ git+https://github.com/openshift/openstack-sushy@14d9be9efe71534fbad150ee3d40f7c9919f387b
+sushy @ git+https://github.com/openshift/openstack-sushy@e085fc0e44e34f036620b724986ee41831111d5b
 
 proliantutils===2.16.3
 sushy-oem-idrac===6.0.0


### PR DESCRIPTION
Update sushy dependency in `requirements.cachito` to include the fix for
NVIDIA DGX B200 VirtualMedia InsertMedia credential detection failure.

The DGX B200 BMC returns `ActionParameterMissing` via `@Message.ExtendedInfo`
instead of a structured `error.code` field, causing the existing credential
detection logic to fail. The updated sushy version includes improved
`is_credentials_required()` handling that detects these unstructured error
responses and retries with `UserName`/`Password` parameters.

Sushy backport PR: https://github.com/openshift/openstack-sushy/pull/144
Upstream fix: https://review.opendev.org/c/openstack/sushy/+/964871
