### PR TITLE
OCPBUGS-74405: Update sushy to include DGX B200 credentials fix

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,5 +1,5 @@
 ironic @ git+https://github.com/openshift/openstack-ironic@7f00f86b55daa40d5217a80ad21a3fda661b16e3
-sushy @ git+https://github.com/openshift/openstack-sushy@618e1f05507c5ee2ce917117dc5e0b98eb4d2399
+sushy @ git+https://github.com/openshift/openstack-sushy@e481e39eebc2e4c72a929166ea6ab99c53535139
 
 proliantutils===2.16.3
 python-scciclient===0.17.0


### PR DESCRIPTION
Update sushy dependency in `requirements.cachito` to include the fix for
NVIDIA DGX B200 VirtualMedia InsertMedia credential detection failure.

The DGX B200 BMC returns `ActionParameterMissing` via `@Message.ExtendedInfo`
instead of a structured `error.code` field, causing the existing credential
detection logic to fail. The updated sushy version includes improved
`is_credentials_required()` handling that detects these unstructured error
responses and retries with `UserName`/`Password` parameters.

Sushy backport PR: https://github.com/openshift/openstack-sushy/pull/140
Upstream fix: https://review.opendev.org/c/openstack/sushy/+/964871
