### PR TITLE
OCPBUGS-74407: Update sushy to include DGX B200 credentials fix

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,5 +1,5 @@
 ironic @ git+https://github.com/openshift/openstack-ironic@d93a60135baf0ed7e05b0da26232f076fcec4d81
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@96ac462d0c3d53c70256cb048e42c317cc41b682
-sushy @ git+https://github.com/openshift/openstack-sushy@0a69336cf002592211bd78b8601a84ab66915527
+sushy @ git+https://github.com/openshift/openstack-sushy@3b58c7cc870d92e7d575ce476ca7c8a5863081d7
 
 # DEPENDENCIES


### PR DESCRIPTION
Update sushy dependency in `requirements.cachito` to include the fix for
NVIDIA DGX B200 VirtualMedia InsertMedia credential detection failure.

The DGX B200 BMC returns `ActionParameterMissing` via `@Message.ExtendedInfo`
instead of a structured `error.code` field, causing the existing credential
detection logic to fail. The updated sushy version includes improved
`is_credentials_required()` handling that detects these unstructured error
responses and retries with `UserName`/`Password` parameters.

Sushy backport PR: https://github.com/openshift/openstack-sushy/pull/145
Upstream fix: https://review.opendev.org/c/openstack/sushy/+/964871

Changes:
- `requirements.cachito`: sushy hash updated from `0a69336` to `3b58c7c`