### PR TITLE
DNM, testing CI: Drop potentially faulty commit to test CI

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,5 +1,5 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@f8686d33cf45e128c7d58e055c0c0ddf27e3d959
-sushy @ git+https://github.com/openshift/openstack-sushy@5a6b97ea02edae6f709a3ced09db7c88c57ae5ef
+ironic @ git+https://github.com/MahnoorAsghar/openstack-ironic@923a08ecaa4f92dd8c753b034ba0a8f3b3d71430
+sushy @ git+https://github.com/openshift/openstack-sushy@6094f72fda9c198ce1b3c531cd97c2421dcc4489
 
 proliantutils===2.16.3
 python-scciclient===0.17.0


### PR DESCRIPTION
See first commit on https://github.com/MahnoorAsghar/openstack-ironic/commits/drop-potentially-faulty-commit/ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Git-pinned package dependencies for ironic and sushy to newer commit references to keep third-party integrations current. No other dependency changes or functional updates included. Expected low review effort and minimal user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->