### PR TITLE
OKD-362: Add watchdog to python-requirements.okd

### DIFF
--- a/python-requirements.okd
+++ b/python-requirements.okd
@@ -5,3 +5,4 @@ pyghmi
 python-scciclient
 pyasyncore
 pyinotify
+watchdog

--- a/python-requirements.okd
+++ b/python-requirements.okd
@@ -3,6 +3,4 @@ git+https://github.com/openshift/openstack-ironic
 proliantutils
 pyghmi
 python-scciclient
-pyasyncore
-pyinotify
 watchdog


### PR DESCRIPTION
## Summary

Fixes https://github.com/okd-project/okd/issues/2321

The massive upstream merge (3240962) switched `runlogwatch.sh` and
`tls-common.sh` from `pyinotify` to `watchmedo` (from the `watchdog`
Python package), consistent with upstream commit 8a63f41. The OCP
package list (`main-packages-list.ocp`) already includes
`python3.12-watchdog`, but the OKD/SCOS pip requirements file
(`python-requirements.okd`) was never updated — causing
`watchmedo: command not found` at runtime in the `metal3-ramdisk-logs`
sidecar.

This PR:
- Adds `watchdog` to `python-requirements.okd`
- Removes `pyinotify` and `pyasyncore`, which are no longer used after
  the switch to `watchmedo` (`pyasyncore` was only needed as a
  `pyinotify` dependency for Python 3.12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python package dependencies to improve system compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->