### PR TITLE
OCPBUGS-83618: Bump sushy to latest

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,5 +1,5 @@
 ironic @ git+https://github.com/openshift/openstack-ironic@f8686d33cf45e128c7d58e055c0c0ddf27e3d959
-sushy @ git+https://github.com/openshift/openstack-sushy@5a6b97ea02edae6f709a3ced09db7c88c57ae5ef
+sushy @ git+https://github.com/openshift/openstack-sushy@6094f72fda9c198ce1b3c531cd97c2421dcc4489
 
 proliantutils===2.16.3
 python-scciclient===0.17.0


### PR DESCRIPTION
CI seems unstable on the auto-sync
Let's try to only bump sushy to see how CI will behave

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->