### PR TITLE
NO-ISSUE: Document how to use gerrit change hash for testing

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,3 +1,16 @@
+# Packages are pinned to commit hashes from the OpenShift forks on GitHub.
+# The format is: <package> @ git+<github_url>@<commit_sha>
+#
+# For testing with an upstream Gerrit change, you can temporarily
+# replace the URL and hash with the upstream repo and patchset commit SHA,
+# for example for ironic:
+#   ironic @ git+https://opendev.org/openstack/ironic@<patchset_commit_sha>
+#
+# Where <patchset_commit_sha> can be obtained from the gerrit UI.
+#
+# Note: this will fail CI checks (check-requirements.sh) and the downstream
+# Cachito build pipeline, so revert before submitting a PR.
+
 ironic @ git+https://github.com/openshift/openstack-ironic@f8686d33cf45e128c7d58e055c0c0ddf27e3d959
 sushy @ git+https://github.com/openshift/openstack-sushy@5a6b97ea02edae6f709a3ced09db7c88c57ae5ef
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies: pinned ironic and sushy packages to specific GitHub commit SHAs from OpenShift forks
  * Added documentation explaining the commit-hash pinning scheme for OpenShift forked dependencies and instructions for testing upstream patches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->