### PR TITLE
METAL-1838: Bump setuptools version to align with latest ironic requirements

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -20,7 +20,7 @@ RUN set -euxo pipefail && \
     echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
     dnf install -y \
         python3.12-pip \
-        'python3.12-setuptools >= 70.3.0' \
+        'python3.12-setuptools >= 78.1.1' \
         python3.12-setuptools_scm \
         python3.12-pbr \
         python3.12-devel \

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -23,6 +23,8 @@ python3.12-debtcollector >= 3.0.0-0.20250214185317.0e6ce1c.el9
 python3.12-defusedxml >= 0.7.1-1.el9
 python3.12-eventlet >= 0.40.3-2.el9ocp
 python3.12-flask >= 1:2.2.5-3.1.el9ocp
+python3.12-flexcache >= 0.3-3.el9ocp
+python3.12-flexparser >= 0.4-1.el9ocp
 python3.12-futurist >= 3.2.1
 python3.12-gunicorn >= 20.0.4-4.1.el9ocp
 python3.12-inotify >= 0.9.6-26.el9ocp
@@ -65,7 +67,7 @@ python3.12-paste >= 3.5.0-3.el9.1
 python3.12-paste-deploy >= 2.0.1-5.el9
 python3.12-pbr >= 6.0.0-1.el9
 python3.12-pecan
-python3.12-pint >= 0.10.1-3.el9
+python3.12-pint >= 0.24.4-2.el9ocp
 python3.12-psutil
 python3.12-pyasn1 >= 0.5.1-5.el9ocp
 python3.12-pyasn1-modules >= 0.5.1-5.el9ocp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum Python setuptools version used during image builds to improve build reliability and stability.
  * Added new Python runtime packages for improved parsing and caching capabilities.
  * Bumped the minimum version requirement for the Python units/measurement library to a newer release for compatibility and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->