### PR TITLE
METAL-1865: Extract wheel-builder build deps to build-packages-list.ocp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -14,21 +14,13 @@ FROM registry.ci.openshift.org/ocp/5.0:base-rhel9 AS wheel-builder
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-"requirements*.cachito"}
 ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-"/remote_sources_dir/"}
 
+COPY build-packages-list.ocp /tmp/
+
 # Install build dependencies
 RUN set -euxo pipefail && \
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
     echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
-    dnf install -y \
-        python3.12-pip \
-        'python3.12-setuptools >= 78.1.1' \
-        'python3.12-packaging >= 24.2' \
-        python3.12-setuptools_scm \
-        python3.12-pbr \
-        python3.12-devel \
-        python3.12-wheel \
-        gcc \
-        gcc-c++ \
-        git-core
+    xargs -rtd'\n' dnf install -y < /tmp/build-packages-list.ocp
 
 # Copy cachito sources
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"

--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -1,0 +1,10 @@
+gcc
+gcc-c++
+git-core
+python3.12-devel
+python3.12-packaging >= 24.2
+python3.12-pbr
+python3.12-pip
+python3.12-setuptools >= 78.1.1
+python3.12-setuptools_scm
+python3.12-wheel


### PR DESCRIPTION
Move the DNF packages installed in the wheel-builder stage from inline Dockerfile.ocp to a dedicated build-packages-list.ocp file. This ensures changes to build dependencies trigger CI prevalidation jobs, matching the pattern used for main-packages-list.ocp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Docker build process to manage build dependencies through an external configuration file for improved maintainability and easier future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->