### PR TITLE
NO-ISSUE: Add --no-index back and remove pip at the end

### DIFF
--- a/build-wheels-ocp.sh
+++ b/build-wheels-ocp.sh
@@ -18,7 +18,7 @@ fi
 # to use build tools already installed in the system, for our case
 # setuptools and pbr, instead of installing them in the isolated
 # pip environment.
-WHEEL_OPTIONS="--no-cache-dir --no-build-isolation"
+WHEEL_OPTIONS="--no-cache-dir --no-build-isolation --no-index"
 
 # NOTE(elfosardo): download all the libraries and dependencies first,
 # using --no-deps to avoid chain-downloading packages.

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -42,6 +42,8 @@ if [[ -f /tmp/main-packages-list.ocp ]]; then
     # compile post-install (see RHEL-29028)
     python3.12 -m compileall --invalidation-mode=timestamp -q -x '/usr/share/doc' /usr
 
+    dnf remove -y python3.12-pip
+
     # ironic system configuration
     mkdir -p /var/log/ironic /var/lib/ironic
     getent group ironic >/dev/null || groupadd -r -g "${IRONIC_GID}" ironic


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified wheel-building configuration to use local package sources exclusively, adjusting build options to prevent pip from consulting external package indexes during the wheel compilation phase.
  * Refined image preparation by removing the pip package after bytecode compilation completes, reducing the final image by eliminating unnecessary build dependencies and unused tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->