### PR TITLE
NO-ISSUE: Filter blank lines from build-packages-list.ocp in Dockerfile

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -20,7 +20,7 @@ COPY build-packages-list.ocp /tmp/
 RUN set -euxo pipefail && \
     echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
     echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
-    grep -v '^#' /tmp/build-packages-list.ocp | xargs -rtd'\n' dnf install -y
+    grep -vE '^(#|$)' /tmp/build-packages-list.ocp | xargs -rtd'\n' dnf install -y
 
 # Copy cachito sources
 COPY "$REMOTE_SOURCES" "$REMOTE_SOURCES_DIR"

--- a/build-packages-list.ocp
+++ b/build-packages-list.ocp
@@ -1,25 +1,32 @@
 # C/C++ compilers for building Python C extensions (psutil, greenlet, etc.)
 gcc
 gcc-c++
+
 # needed by pip to fetch packages from git URLs
 git-core
+
 # Python headers for building C extensions
 python3.12-devel
+
 # build backends required by various packages in requirements.cachito
 python3.12-flit-core
 python3.12-hatch-fancy-pypi-readme
 python3.12-hatch-vcs
 python3.12-hatchling >= 1.21.1-1.1.el9ocp
 python3.12-packaging >= 24.2-1.el9ocp
+
 # used by most OpenStack packages as their build system
 python3.12-pbr
 python3.12-poetry-core
+
 # pip and wheel for downloading and building wheels
 python3.12-pip
 python3.12-setuptools >= 78.1.1
+
 # needed by bcrypt 4.x to compile its Rust-based _bcrypt extension
 python3.12-setuptools-rust
 python3.12-setuptools_scm
+
 # test dependencies pulled in by some OpenStack packages at build time
 python3.12-testresources >= 2.0.1
 python3.12-testscenarios >= 0.5.0


### PR DESCRIPTION
grep -v '^#' passes blank lines through to xargs, which can result in empty arguments to dnf install. Switch to grep -vE '^(#|$)' to strip both comments and blank lines in one pass.

Also add blank lines between sections in build-packages-list.ocp for readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by ignoring blank lines in the build package list.

* **Style**
  * Reformatted the build dependency list into clearer grouped sections without changing its contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->