### PR TITLE
[release-4.22] OCPBUGS-98873: Selectively backport Redfish firmware update fix to 4.22

### DIFF
--- a/patches/0054-Fix-Redfish-firmware-update-handling-of-NEW-task-state.patch
+++ b/patches/0054-Fix-Redfish-firmware-update-handling-of-NEW-task-state.patch
@@ -1,0 +1,121 @@
+From 95cae9eb471e226b4384efda909aaa173afdaf48 Mon Sep 17 00:00:00 2001
+From: Jacob Anders <jacob-anders-dev@proton.me>
+Date: Tue, 14 Jul 2026 23:06:26 +1000
+Subject: [PATCH] Fix Redfish firmware update handling of NEW task state
+
+Some BMCs (notably Dell iDRAC) return TaskState.NEW immediately after a
+SimpleUpdate request before transitioning to Starting. This state was
+not recognized as in-progress and was treated as a terminal failure,
+causing firmware updates to abort with "Error: New".
+
+Add TASK_STATE_NEW to the list of in-progress states in
+_handle_firmware_update_task so it is no longer misclassified.
+
+Also fix _query_update_status to use firmware_update_status_interval
+for its polling spacing instead of firmware_update_fail_interval
+(copy-paste error from _query_update_failed).
+
+Assisted-By: Claude Opus 4.6
+Change-Id: I4bc9326374cc4ab22d3caef81fcfad74f4d3ed00
+Signed-off-by: Jacob Anders <jacob-anders-dev@proton.me>
+---
+
+diff --git a/ironic/drivers/modules/redfish/firmware.py b/ironic/drivers/modules/redfish/firmware.py
+index 1080d95..6ed2287 100644
+--- a/ironic/drivers/modules/redfish/firmware.py
++++ b/ironic/drivers/modules/redfish/firmware.py
+@@ -943,7 +943,7 @@
+     @METRICS.timer('RedfishFirmware._query_update_status')
+     @periodics.node_periodic(
+         purpose='checking async update of firmware component',
+-        spacing=CONF.redfish.firmware_update_fail_interval,
++        spacing=CONF.redfish.firmware_update_status_interval,
+         filters={'reserved': False, 'provision_state_in': [states.CLEANWAIT,
+                  states.DEPLOYWAIT, states.SERVICEWAIT]},
+         predicate_extra_fields=['driver_internal_info'],
+@@ -1389,10 +1389,11 @@
+ 
+         # Check if task is in a terminal state (completed, failed, etc.)
+         # If so, proceed directly to completion handling
+-        if task_state not in [sushy.TASK_STATE_RUNNING,
++        if task_state not in [sushy.TASK_STATE_NEW,
++                              sushy.TASK_STATE_RUNNING,
+                               sushy.TASK_STATE_STARTING,
+                               sushy.TASK_STATE_PENDING]:
+-            # Taks is done (COMPLETED, EXCEPTION, KILLED, CANCELLED, etc.)
++            # Task is done (COMPLETED, EXCEPTION, KILLED, CANCELLED, etc.)
+             # Parse messages and handle completion
+             LOG.debug('Firmware update task in terminal state %(state)s '
+                       'for node %(node)s',
+@@ -1417,7 +1418,7 @@
+                                          current_update)
+             return
+ 
+-        # Task is still in progress (RUNNING, STARTING, or PENDING)
++        # Task is still in progress (NEW, RUNNING, STARTING, or PENDING)
+         # Special handling for BIOS and NIC updates
+         component = current_update.get('component', '')
+         component_type = redfish_utils.get_component_type(component)
+diff --git a/ironic/tests/unit/drivers/modules/redfish/test_firmware.py b/ironic/tests/unit/drivers/modules/redfish/test_firmware.py
+index 68342e8..ec10c50 100644
+--- a/ironic/tests/unit/drivers/modules/redfish/test_firmware.py
++++ b/ironic/tests/unit/drivers/modules/redfish/test_firmware.py
+@@ -1185,6 +1185,36 @@
+             log_mock.debug.assert_has_calls(debug_calls)
+             interface._continue_updates.assert_not_called()
+ 
++    @mock.patch.object(redfish_fw, 'LOG', autospec=True)
++    @mock.patch.object(redfish_utils, 'get_update_service', autospec=True)
++    @mock.patch.object(redfish_utils, 'get_task_monitor', autospec=True)
++    def test__check_update_task_state_new(self, tm_mock, get_us_mock,
++                                          log_mock):
++        """Test task in NEW state is treated as in-progress, not terminal.
++
++        Dell iDRAC returns TaskState.NEW immediately after a SimpleUpdate
++        request before the task transitions to STARTING. This must not be
++        treated as a terminal state, otherwise the firmware update is
++        incorrectly declared as failed.
++        """
++        self._generate_new_driver_internal_info(['bmc'])
++
++        tm_mock.return_value.is_processing = False
++        mock_task = tm_mock.return_value.get_task.return_value
++        mock_task.task_state = sushy.TASK_STATE_NEW
++        mock_task.task_status = sushy.HEALTH_OK
++
++        _, interface = self._test__check_node_redfish_firmware_update()
++
++        debug_calls = [
++            mock.call('Firmware update in progress for node %(node)s, '
++                      'firmware %(firmware_image)s.',
++                      {'node': self.node.uuid,
++                       'firmware_image': 'https://bmc/v1.0.1'})]
++
++        log_mock.debug.assert_has_calls(debug_calls)
++        interface._continue_updates.assert_not_called()
++
+     @mock.patch.object(manager_utils, 'cleaning_error_handler', autospec=True)
+     @mock.patch.object(redfish_utils, 'get_update_service', autospec=True)
+     @mock.patch.object(redfish_utils, 'get_task_monitor', autospec=True)
+diff --git a/releasenotes/notes/fix-firmware-update-new-task-state-ae20a293c30843ba.yaml b/releasenotes/notes/fix-firmware-update-new-task-state-ae20a293c30843ba.yaml
+new file mode 100644
+index 0000000..d62d129
+--- /dev/null
++++ b/releasenotes/notes/fix-firmware-update-new-task-state-ae20a293c30843ba.yaml
+@@ -0,0 +1,16 @@
++---
++fixes:
++  - |
++    Fixes a bug where Redfish firmware updates were incorrectly declared as
++    failed when the BMC task was in the ``New`` state. Some BMCs, notably Dell
++    iDRAC, return ``TaskState.NEW`` immediately after a ``SimpleUpdate``
++    request before the task transitions to ``Starting``. Previously, the
++    ``New`` state was not recognized as an in-progress state and was treated
++    as a terminal failure, causing the firmware update to be aborted with a
++    misleading error message such as ``Error: New``.
++  - |
++    Fixes the ``_query_update_status`` periodic task to use the
++    ``[redfish]firmware_update_status_interval`` configuration option for its
++    polling interval instead of ``[redfish]firmware_update_fail_interval``.
++    Both options default to 60 seconds, so this was only visible when they
++    were explicitly configured to different values.


### PR DESCRIPTION
Selectively backport Redfish firmware update fix to 4.22 - required by OCPBUGS-98873