### PR TITLE
METAL-1912: Add PQC support until we have pqc minimal images available

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -51,6 +51,9 @@ RUN --mount=from=wheel-builder,source=/wheels,target=/wheels \
     /bin/prepare-ipxe.sh && \
     rm -f /bin/prepare-ipxe.sh
 
+# Add PQC support until we have pqc enabled ubi minimal images available
+RUN update-crypto-policies --set DEFAULT:PQ
+
 # IRONIC #
 COPY --from=builder /tmp/uefi_esp_*.img /templates/
 

--- a/Dockerfile.scos
+++ b/Dockerfile.scos
@@ -26,6 +26,9 @@ RUN prepare-image.sh && \
     /bin/prepare-ipxe.sh && \
     rm -f /bin/prepare-ipxe.sh
 
+# Add PQC support until we have pqc enabled ubi minimal images available
+RUN update-crypto-policies --set DEFAULT:PQ
+
 # IRONIC #
 COPY --from=builder /tmp/uefi_esp_*.img /tmp/
 

--- a/main-packages-list.ocp
+++ b/main-packages-list.ocp
@@ -88,3 +88,4 @@ qemu-img
 sqlite
 util-linux
 xorriso
+crypto-policies-scripts

--- a/main-packages-list.okd
+++ b/main-packages-list.okd
@@ -15,3 +15,4 @@ qemu-img
 sqlite
 util-linux
 xorriso
+crypto-policies-scripts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Enabled post-quantum cryptography (PQC) by setting crypto policies to `DEFAULT:PQ` in OpenShift and CentOS Stream 9 runtime images.
  * Ensures crypto policy tooling is included so the PQC configuration is applied during image preparation.
  * Improves readiness for emerging post-quantum cryptographic standards in supported deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->