### PR TITLE
[release-4.22] OCPBUGS-100167: Update openstack-ironic commit hash for CVE-2026-44918

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@c4a17e4e9d067930a0473afaf197b5a107a08d7e
+ironic @ git+https://github.com/openshift/openstack-ironic@7e602bd9e70abbfcab8bce96e1394d20a8f92761
 sushy @ git+https://github.com/openshift/openstack-sushy@7e6b973f3a252929d7f2699a057504758b07b670
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary
Update the openstack-ironic pin in `requirements.cachito` so the 4.22 ironic image builds with the CVE-2026-44918 fix.

`openshift/openstack-ironic` PR #456 is already merged to `release-4.22`. This bumps the pinned commit from `c4a17e4e…` to `7e602bd9e70abbfcab8bce96e1394d20a8f92761` (merge of that PR).

Without this bump, the image continues to ship the pre-fix Ironic SHA even though the source PR is merged.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/456
- Commit: 7e602bd9e70abbfcab8bce96e1394d20a8f92761
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html

## Jira
OCPBUGS-100167