### PR TITLE
[release-4.21] OCPBUGS-97991: Update openstack-ironic commit hash for CVE-2026-44918

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@fbf5d928dd370ae1fe9138a3c2fb3be52839fcc8
+ironic @ git+https://github.com/openshift/openstack-ironic@6acc6b897cda935c43c1c3270843738bd3e59223
 sushy @ git+https://github.com/openshift/openstack-sushy@e5fdbebaa18a8e8f1f9bd9347079403dadb037c3
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary
Update the openstack-ironic pin in `requirements.cachito` so the 4.21 ironic image builds with the CVE-2026-44918 fix.

`openshift/openstack-ironic` PR #454 is already merged to `release-4.21`. This bumps the pinned commit from `fbf5d928…` to `6acc6b897cda935c43c1c3270843738bd3e59223` (merge of that PR).

Without this bump, the image continues to ship the pre-fix Ironic SHA even though the source PR is merged.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/454
- Commit: 6acc6b897cda935c43c1c3270843738bd3e59223
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html

## Jira
OCPBUGS-97991