### PR TITLE
OCPBUGS-104459: bump openstack-ironic pin for CVE-2026-54423 fix(release-4.16)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@0aa8e1dc4cf30e71ab456ae7c61cac431d06059a
+ironic @ git+https://github.com/openshift/openstack-ironic@2acd02d80203084f5fbd21dfb7b4031930765318
 ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@4bfd8f8fdb6c2af646d3d418839b463fb9495256
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@4c435d91ea767bbb251376a28f6eeacd09ae680b
 sushy @ git+https://github.com/openshift/openstack-sushy@a14fcfbbbe43121858808099ffc909924fca1410


### PR DESCRIPTION
## Summary
- Update `requirements.cachito` to pin `openstack-ironic` to commit `2acd02d80203084f5fbd21dfb7b4031930765318` which includes the CVE-2026-54423 fix
- The referenced commit removes `@base.deploy_step`, `@base.clean_step`, and `@base.service_step` decorators from `VendorPassthru.send_raw`, preventing it from being invoked through deploy/clean/service step workflows

## openstack-ironic PR
https://github.com/openshift/openstack-ironic/pull/466 (merged)

## Bug
https://issues.redhat.com/browse/OCPBUGS-104459

## Upstream fix reference
https://github.com/openstack/ironic/commit/7bbe5a2da24e

Made with [Cursor](https://cursor.com)