### PR TITLE
OCPBUGS-97807: bump openstack-ironic pin for CVE-2026-54423 fix(release-4.15)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@1aa3dd8a43019ab158d5115ffc622172ccd7efd2
+ironic @ git+https://github.com/openshift/openstack-ironic@c91c37923c8202b414f08a87873bb61ab4621596
 ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@de56b734e9f52294e622863814141b7b20201cad
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@eb085accdbfd8824d3e2a697a56e89820941164a
 sushy @ git+https://github.com/openshift/openstack-sushy@45b2933b76a9a80cf6f36fa6296f6c17e397b8c6


### PR DESCRIPTION
## Summary
- Update `requirements.cachito` to pin `openstack-ironic` to commit `c91c37923c8202b414f08a87873bb61ab4621596` which includes the CVE-2026-54423 fix
- The referenced commit removes `@base.deploy_step`, `@base.clean_step`, and `@base.service_step` decorators from `VendorPassthru.send_raw`, preventing it from being invoked through deploy/clean/service step workflows

## openstack-ironic PR
https://github.com/openshift/openstack-ironic/pull/467 (merged)

## Bug
https://issues.redhat.com/browse/OCPBUGS-97807

## Upstream fix reference
https://github.com/openstack/ironic/commit/7bbe5a2da24e

Made with [Cursor](https://cursor.com)