### PR TITLE
OCPBUGS-97806: bump openstack-ironic pin for CVE-2026-54423 fix(release-4.14)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@bd039933047d9b7ca1fea10bd32cf2ee0e3d1821
+ironic @ git+https://github.com/openshift/openstack-ironic@3f0dfcbdd2ecb3871ca54e8af8ab20ca9ad5bbbb
 ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@2129f87edde8240d2d26be28005a2552f71f67d6
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@6f6a0d7cab85358fbf94fd1e248ee220895deedd
 sushy @ git+https://github.com/openshift/openstack-sushy@3ffcc6ee8c717fbbc151929898c1ea5daebcd891


### PR DESCRIPTION
## Summary
- Update `requirements.cachito` to pin `openstack-ironic` to commit `3f0dfcbdd2ecb3871ca54e8af8ab20ca9ad5bbbb` which includes the CVE-2026-54423 fix
- The referenced commit removes `@base.deploy_step`, `@base.clean_step`, and `@base.service_step` decorators from `VendorPassthru.send_raw`, preventing it from being invoked through deploy/clean/service step workflows

## openstack-ironic PR
https://github.com/openshift/openstack-ironic/pull/468 (merged)

## Bug
https://issues.redhat.com/browse/OCPBUGS-97806

## Upstream fix reference
https://github.com/openstack/ironic/commit/7bbe5a2da24e

Made with [Cursor](https://cursor.com)