### PR TITLE
[release-4.20] OCPBUGS-100166: Update openstack-ironic commit hash for CVE-2026-44918

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@726b7462d8ef5b24c68215182802877222728664
+ironic @ git+https://github.com/openshift/openstack-ironic@de0a8c0f5938b195fcc5da5dd78394f481eec537
 sushy @ git+https://github.com/openshift/openstack-sushy@be57a1958eb72c5a28997222d1729120e955ceef
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary
Update the openstack-ironic pin in `requirements.cachito` so the 4.20 ironic image builds with the CVE-2026-44918 fix.

`openshift/openstack-ironic` PR #457 is already merged to `release-4.20`. This bumps the pinned commit from `726b7462…` to `de0a8c0f5938b195fcc5da5dd78394f481eec537` (merge of that PR).

Without this bump, the image continues to ship the pre-fix Ironic SHA even though the source PR is merged.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/457
- Commit: de0a8c0f5938b195fcc5da5dd78394f481eec537
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html

## Jira
OCPBUGS-100166