### PR TITLE
[release-4.19] OCPBUGS-100165: Update openstack-ironic commit hash for CVE-2026-44918

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@205cab3f891da48480377faf1f596c22e9bf82ea
+ironic @ git+https://github.com/openshift/openstack-ironic@0b2913e02715aebe532297084593e5f2b08dd462
 sushy @ git+https://github.com/openshift/openstack-sushy@e085fc0e44e34f036620b724986ee41831111d5b
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary
Update the openstack-ironic pin in `requirements.cachito` so the 4.19 ironic image builds with the CVE-2026-44918 fix.

`openshift/openstack-ironic` PR #458 is already merged to `release-4.19`. This bumps the pinned commit from `205cab3f…` to `0b2913e02715aebe532297084593e5f2b08dd462` (merge of that PR).

Without this bump, the image continues to ship the pre-fix Ironic SHA even though the source PR is merged.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/458
- Commit: 0b2913e02715aebe532297084593e5f2b08dd462
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html

## Jira
OCPBUGS-100165