### PR TITLE
OKD-421: Fix Dockerfile.scos crypto-policies PQ failure on CentOS Stream 10

### DIFF
--- a/Dockerfile.scos
+++ b/Dockerfile.scos
@@ -27,8 +27,10 @@ RUN prepare-image.sh && \
     /bin/prepare-ipxe.sh && \
     rm -f /bin/prepare-ipxe.sh
 
-# Add PQC support until we have pqc enabled ubi minimal images available
-RUN update-crypto-policies --set DEFAULT:PQ
+# Add PQC support - on Stream 9 apply the PQ subpolicy; Skip if on Stream 10+ as PQ is already in DEFAULT
+RUN if [ -f /usr/share/crypto-policies/policies/modules/PQ.pmod ]; then \
+      update-crypto-policies --set DEFAULT:PQ; \
+    fi
 
 # IRONIC #
 COPY --from=builder /tmp/uefi_esp_*.img /tmp/


### PR DESCRIPTION
When generating 4.22 OKD configs, ironic-image failed with the [following error](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/83137/rehearse-83137-pull-ci-openshift-ironic-image-main-okd-scos-e2e-aws-ovn/2086858960500953088#1:build-log.txt%3A2417):

```
[2/2] STEP 11/25: RUN update-crypto-policies --set DEFAULT:PQ
Unknown policy `PQ`: file `PQ.pmod` not found in (., policies/modules, /etc/crypto-policies/policies/modules, /usr/share/crypto-policies/policies/modules)
error: build error: building at ST
```

This is due to CentOS stream 10 no longer shipping PQ.pmod since it comes with post quantum by default. The fix is to have a simple conditional to handle the error gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PQC configuration compatibility for Stream 10+ images.
  * Preserved the default security policy when the PQ policy module is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->