### PR TITLE
[release-4.18] OCPBUGS-100164: Update openstack-ironic commit hash for CVE-2026-44918

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@d93a60135baf0ed7e05b0da26232f076fcec4d81
+ironic @ git+https://github.com/openshift/openstack-ironic@6ef714bf5c03de53cf74bf1438431ea78a66bd7f
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@96ac462d0c3d53c70256cb048e42c317cc41b682
 sushy @ git+https://github.com/openshift/openstack-sushy@3b58c7cc870d92e7d575ce476ca7c8a5863081d7
 


### PR DESCRIPTION
## Summary
Update the openstack-ironic pin in `requirements.cachito` so the 4.18 ironic image builds with the CVE-2026-44918 fix.

`openshift/openstack-ironic` PR #459 is already merged to `release-4.18`. This bumps the pinned commit from `d93a6013…` to `6ef714bf5c03de53cf74bf1438431ea78a66bd7f` (merge of that PR).

Without this bump, the image continues to ship the pre-fix Ironic SHA even though the source PR is merged.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/459
- Commit: 6ef714bf5c03de53cf74bf1438431ea78a66bd7f
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html

## Jira
OCPBUGS-100164