### PR TITLE
OCPBUGS-105863: update ironic pin to include CVE-2026-54423 fix (release-4.22)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@7e602bd9e70abbfcab8bce96e1394d20a8f92761
+ironic @ git+https://github.com/openshift/openstack-ironic@b3b1c131e009c945f0cdf9d66537ff413fbf1168
 sushy @ git+https://github.com/openshift/openstack-sushy@7e6b973f3a252929d7f2699a057504758b07b670
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary

- Updates the `openstack-ironic` commit pin in `requirements.cachito` to include the CVE-2026-54423 fix.

## Details

| | Old | New |
|---|---|---|
| **Pinned commit** | `7e602bd9e70a` | `b3b1c131e009` |

The new pin points to the HEAD of `openshift/openstack-ironic` `release-4.22`, which includes the merge of [openshift/openstack-ironic#476](https://github.com/openshift/openstack-ironic/pull/476) — the fix for CVE-2026-54423 (vendor.send_raw RBAC bypass).

Without this update, the container image build continues using the old, unfixed ironic code.

## Tracker

- **OCPBUGS-105863**
- **CVE:** CVE-2026-54423


Made with [Cursor](https://cursor.com)