### PR TITLE
OCPBUGS-105861: update ironic pin to include CVE-2026-54423 fix (release-4.21)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@3517857c04c6e51977ec1442b4bdbc3df4f1c011
+ironic @ git+https://github.com/openshift/openstack-ironic@d2ce0d1aef2d040c846efd97fc8bddaffa6d3902
 sushy @ git+https://github.com/openshift/openstack-sushy@e5fdbebaa18a8e8f1f9bd9347079403dadb037c3
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary

- Updates the `openstack-ironic` commit pin in `requirements.cachito` to include the CVE-2026-54423 fix.

## Details

| | Old | New |
|---|---|---|
| **Pinned commit** | `3517857c04c6` | `d2ce0d1aef2d` |

The new pin points to the HEAD of `openshift/openstack-ironic` `release-4.21`, which includes the merge of [openshift/openstack-ironic#477](https://github.com/openshift/openstack-ironic/pull/477) — the fix for CVE-2026-54423 (vendor.send_raw RBAC bypass).

Without this update, the container image build continues using the old, unfixed ironic code.

## Tracker

- **OCPBUGS-105861**
- **CVE:** CVE-2026-54423


Made with [Cursor](https://cursor.com)