### PR TITLE
OCPBUGS-105862: update ironic pin to include CVE-2026-54423 fix (release-4.20)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@8a4e7187453e0043ca4da4a29394bc3e209032de
+ironic @ git+https://github.com/openshift/openstack-ironic@330bcbb08d556b9d41757741470b5f39dbe11bc3
 sushy @ git+https://github.com/openshift/openstack-sushy@be57a1958eb72c5a28997222d1729120e955ceef
 
 proliantutils===2.16.3


### PR DESCRIPTION
## Summary

- Updates the `openstack-ironic` commit pin in `requirements.cachito` to include the CVE-2026-54423 fix.

## Details

| | Old | New |
|---|---|---|
| **Pinned commit** | de0a8c0f5938 | 330bcbb08d55 |

The new pin points to the HEAD of `openshift/openstack-ironic` `release-4.20`, which includes the merge of openshift/openstack-ironic#478 — the fix for CVE-2026-54423 (vendor.send_raw RBAC bypass).

Without this update, the container image build continues using the old, unfixed ironic code.

## Tracker

- **OCPBUGS-105862**
- **CVE:** CVE-2026-54423

Made with [Cursor](https://cursor.com)