### PR TITLE
OCPBUGS-105860: update ironic pin to include CVE-2026-54423 fix (release-4.18)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@6ef714bf5c03de53cf74bf1438431ea78a66bd7f
+ironic @ git+https://github.com/openshift/openstack-ironic@12221fd76ae3df370dd47f87438ba425cd61bc02
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@96ac462d0c3d53c70256cb048e42c317cc41b682
 sushy @ git+https://github.com/openshift/openstack-sushy@3b58c7cc870d92e7d575ce476ca7c8a5863081d7
 


### PR DESCRIPTION
## Summary

- Updates the `openstack-ironic` commit pin in `requirements.cachito` to include the CVE-2026-54423 fix.

## Details

| | Old | New |
|---|---|---|
| **Pinned commit** | d93a60135baf | 12221fd76ae3 |

The new pin points to the HEAD of `openshift/openstack-ironic` `release-4.18`, which includes the merge of openshift/openstack-ironic#480 — the fix for CVE-2026-54423 (vendor.send_raw RBAC bypass).

Without this update, the container image build continues using the old, unfixed ironic code.

## Tracker

- **OCPBUGS-105860**
- **CVE:** CVE-2026-54423

Made with [Cursor](https://cursor.com)