### PR TITLE
OCPBUGS-105859: update ironic pin to include CVE-2026-54423 fix (release-4.17)

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@b59c9ba02f0e0e3185c53afd4cbe383a915b4668
+ironic @ git+https://github.com/openshift/openstack-ironic@3dfee22ce139163aae42160af2077f2c0ad65668
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@7578e8e32e3eb5e07da8806bc0a029e879dbb627
 sushy @ git+https://github.com/openshift/openstack-sushy@e71ea5cd1abf116d3c5b970c2cbba2179e453b17
 


### PR DESCRIPTION
## Summary

- Updates the `openstack-ironic` commit pin in `requirements.cachito` to include the CVE-2026-54423 fix.

## Details

| | Old | New |
|---|---|---|
| **Pinned commit** | b59c9ba02f0e | 3dfee22ce139 |

The new pin points to the HEAD of `openshift/openstack-ironic` `release-4.17`, which includes the merge of openshift/openstack-ironic#481 — the fix for CVE-2026-54423 (vendor.send_raw RBAC bypass).

Without this update, the container image build continues using the old, unfixed ironic code.

## Tracker

- **OCPBUGS-105859**
- **CVE:** CVE-2026-54423

Made with [Cursor](https://cursor.com)