### PR TITLE
[release-4.17] OCPBUGS-100163: Update openstack-ironic commit hash for CVE-2026-44918

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@b59c9ba02f0e0e3185c53afd4cbe383a915b4668
+ironic @ git+https://github.com/openshift/openstack-ironic@6de784dedcc165838a411b1170ab801f6b8aa1a2
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@7578e8e32e3eb5e07da8806bc0a029e879dbb627
 sushy @ git+https://github.com/openshift/openstack-sushy@e71ea5cd1abf116d3c5b970c2cbba2179e453b17
 


### PR DESCRIPTION
## Summary
Update the openstack-ironic pin in `requirements.cachito` so the 4.17 ironic image builds with the CVE-2026-44918 fix.

`openshift/openstack-ironic` PR #460 is already merged to `release-4.17`. This bumps the pinned commit from `b59c9ba0…` to `6de784dedcc165838a411b1170ab801f6b8aa1a2` (merge of that PR).

Without this bump, the image continues to ship the pre-fix Ironic SHA even though the source PR is merged.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/460
- Commit: 6de784dedcc165838a411b1170ab801f6b8aa1a2
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html

## Jira
OCPBUGS-100163