### PR TITLE
NO-ISSUE: Manually sync Ironic and Sushy from the forks

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -26,7 +26,7 @@ automaton===3.3.0
 bcrypt===4.3.0
 cheroot===11.0.0
 construct===2.10.70
-cotyledon===2.0.0
+cotyledon===2.2.0
 futurist===3.2.1
 Jinja2===3.1.6
 jsonpatch===1.33
@@ -53,7 +53,7 @@ oslo.metrics===0.11.0
 oslo.middleware===7.0.0
 oslo.policy===6.0.0
 oslo.serialization===5.8.0
-oslo.service===4.4.1
+oslo.service===4.5.1
 oslo.upgradecheck===2.6.0
 oslo.utils===9.2.0
 oslo.versionedobjects===3.10.2

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -11,9 +11,9 @@
 # Note: this will fail CI checks (check-requirements.sh) and the downstream
 # Cachito build pipeline, so revert before submitting a PR.
 
-ironic @ git+https://github.com/openshift/openstack-ironic@7fb9cfd7db12adfa6fde5bc38609462315edf99b
+ironic @ git+https://github.com/openshift/openstack-ironic@e1f846a51f81772ebf921325bab52613a5012ebb
 ironic-prometheus-exporter @ git+https://github.com/openshift/openstack-ironic-prometheus-exporter@87e6f36f732ddd4d72f13739e03901626546b187
-sushy @ git+https://github.com/openshift/openstack-sushy@71fe4a461b360bfa52b72db7dc9e5f7c42d8bf4e
+sushy @ git+https://github.com/openshift/openstack-sushy@5ab9de95658c55f6ef2d827a480ef311fdb47f0d
 networking-generic-switch @ git+https://github.com/openshift/openstack-networking-generic-switch@747b474d376c3dcdddaae029b055f959e05915c9
 
 # HARDWARE DRIVERS DEPENDENCIES


### PR DESCRIPTION
This sync avoids the change that bumps oslo.versionedobjects.

### Changes

#### Ironic (openshift/openstack-ironic)
- **Previous**: `7fb9cfd7db12adfa6fde5bc38609462315edf99b`
- **New**: `e1f846a51f81772ebf921325bab52613a5012ebb`
- **Compare**: https://github.com/openshift/openstack-ironic/compare/7fb9cfd7db12adfa6fde5bc38609462315edf99b..e1f846a51f81772ebf921325bab52613a5012ebb
#### Sushy (openshift/openstack-sushy)
- **Previous**: `71fe4a461b360bfa52b72db7dc9e5f7c42d8bf4e`
- **New**: `5ab9de95658c55f6ef2d827a480ef311fdb47f0d`
- **Compare**: https://github.com/openshift/openstack-sushy/compare/71fe4a461b360bfa52b72db7dc9e5f7c42d8bf4e..5ab9de95658c55f6ef2d827a480ef311fdb47f0d

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned OpenShift fork revisions for Ironic and Sushy.
  * Upgraded Cotyledon from 2.0.0 to 2.2.0.
  * Upgraded Oslo Service from 4.4.1 to 4.5.1.
  * Kept the Ironic Prometheus Exporter revision unchanged.
  * These updates keep the project aligned with the specified component revisions and package versions without changing exported functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->