### PR TITLE
[4.22] OCPBUGS-115160: bump ironic to include fix

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@c054ce4aff1c4507a68eaac604e5f72fc10e24f9
+ironic @ git+https://github.com/openshift/openstack-ironic@c001ad1104e1662d4decab424cf23d007eb94c2b
 sushy @ git+https://github.com/openshift/openstack-sushy@7e6b973f3a252929d7f2699a057504758b07b670
 
 proliantutils===2.16.3


### PR DESCRIPTION
Bump ironic hash to include a fix to  retry transient 409 conflict on power-on that happens on idrac10 machines