### PR TITLE
[release-4.16] OCPBUGS-100162: bump openstack-ironic pin for CVE-2026-44918 fix

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -1,4 +1,4 @@
-ironic @ git+https://github.com/openshift/openstack-ironic@2acd02d80203084f5fbd21dfb7b4031930765318
+ironic @ git+https://github.com/openshift/openstack-ironic@498792356ce601a2f7be46c3eaa0c167e4190897
 ironic-inspector @ git+https://github.com/openshift/openstack-ironic-inspector@4bfd8f8fdb6c2af646d3d418839b463fb9495256
 ironic-lib @ git+https://github.com/openshift/openstack-ironic-lib@4c435d91ea767bbb251376a28f6eeacd09ae680b
 sushy @ git+https://github.com/openshift/openstack-sushy@a14fcfbbbe43121858808099ffc909924fca1410


### PR DESCRIPTION
## Summary
- Update `requirements.cachito` to pin `openstack-ironic` to commit `498792356ce601a2f7be46c3eaa0c167e4190897`, which includes the CVE-2026-44918 fix
- This commit is the merge of openshift/openstack-ironic#461 and sits on top of the existing `2acd02d8…` pin (CVE-2026-54423), so both fixes are included

## Context
Supersedes openshift/ironic-image#904, which became a no-op after rebasing onto release-4.16 (the merge kept the `2acd02d8…` pin from #877 and dropped the CVE-44918 bump). The 4.16 ironic image currently ships without the CVE-2026-44918 fix even though the source change is already merged in openstack-ironic.

## Related
- openstack-ironic: https://github.com/openshift/openstack-ironic/pull/461
- Commit: 498792356ce601a2f7be46c3eaa0c167e4190897
- OSSA: https://security.openstack.org/ossa/OSSA-2026-026.html
- Supersedes: https://github.com/openshift/ironic-image/pull/904

## Jira
OCPBUGS-100162

## Test plan
- [ ] `ci/prow/check-requirements` passes
- [ ] `ci/prow/prevalidation-images` passes


Made with [Cursor](https://cursor.com)