### PR TITLE
NO-ISSUE: Manually sync Ironic - part 2

### DIFF
--- a/requirements.cachito
+++ b/requirements.cachito
@@ -11,7 +11,7 @@
 # Note: this will fail CI checks (check-requirements.sh) and the downstream
 # Cachito build pipeline, so revert before submitting a PR.
 
-ironic @ git+https://github.com/openshift/openstack-ironic@e1f846a51f81772ebf921325bab52613a5012ebb
+ironic @ git+https://github.com/openshift/openstack-ironic@9abb0ea68a9a5645819ca5df6faf7e336ac2e774
 ironic-prometheus-exporter @ git+https://github.com/openshift/openstack-ironic-prometheus-exporter@87e6f36f732ddd4d72f13739e03901626546b187
 sushy @ git+https://github.com/openshift/openstack-sushy@5ab9de95658c55f6ef2d827a480ef311fdb47f0d
 networking-generic-switch @ git+https://github.com/openshift/openstack-networking-generic-switch@747b474d376c3dcdddaae029b055f959e05915c9
@@ -31,7 +31,7 @@ futurist===3.2.1
 Jinja2===3.1.6
 jsonpatch===1.33
 jsonschema===4.19.2
-keystoneauth1===5.12.0
+keystoneauth1===5.17.0
 keystonemiddleware===10.12.0
 lark===1.3.0
 microversion_parse===2.1.0
@@ -56,7 +56,7 @@ oslo.serialization===5.8.0
 oslo.service===4.5.1
 oslo.upgradecheck===2.6.0
 oslo.utils===9.2.0
-oslo.versionedobjects===3.10.2
+oslo.versionedobjects===3.12.0
 osprofiler===4.4.0
 paramiko===4.0.0
 pbr===7.0.3

--- a/requirements.cachito
+++ b/requirements.cachito
@@ -69,7 +69,7 @@ PyYAML===6.0.3
 requests===2.32.5
 rfc3986===2.0.0
 SQLAlchemy===2.0.44
-stevedore===5.6.0
+stevedore===5.9.1
 tenacity===9.1.2
 tooz===6.3.0
 WebOb===1.8.10


### PR DESCRIPTION
This change bumps oslo.versionedobjects to the new requirement and
updates keystoneauth1 at the same time as merging a fix for it.

### Changes

#### Ironic (openshift/openstack-ironic)
- **Previous**: `e1f846a51f81772ebf921325bab52613a5012ebb`
- **New**: `9abb0ea68a9a5645819ca5df6faf7e336ac2e774`
- **Compare**: https://github.com/openshift/openstack-ironic/compare/e1f846a51f81772ebf921325bab52613a5012ebb..9abb0ea68a9a5645819ca5df6faf7e336ac2e774

Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated underlying project components to newer versions for improved compatibility and maintenance.
  * No user-facing features or behavior changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->