### PR TITLE
METAL-1913: Enable bootc deploy autodetection

### DIFF
--- a/ironic-config/ironic.conf.j2
+++ b/ironic-config/ironic.conf.j2
@@ -11,7 +11,7 @@ http_basic_auth_user_file = /etc/ironic/htpasswd
 auth_strategy = noauth
 {% endif %}
 debug = true
-default_deploy_interface = direct
+default_deploy_interface = autodetect
 default_inspect_interface = agent
 {%- if env.IRONIC_NETWORKING_ENABLED | lower == "true" %}
 default_network_interface = ironic-networking
@@ -20,7 +20,7 @@ default_network_interface = noop
 {% endif -%}
 enabled_bios_interfaces = no-bios,redfish,idrac-redfish
 enabled_boot_interfaces = ipxe,pxe,fake,redfish-virtual-media,idrac-redfish-virtual-media,redfish-https
-enabled_deploy_interfaces = direct,fake,ramdisk,custom-agent,bootc
+enabled_deploy_interfaces = autodetect,direct,fake,ramdisk,custom-agent,bootc
 enabled_firmware_interfaces = no-firmware,fake,redfish
 # NOTE(dtantsur): when changing this, make sure to update the driver
 # dependencies in Dockerfile.ocp.


### PR DESCRIPTION
## Summary

- Change Ironic's default deploy interface from `direct` to `autodetect`.
- Add `autodetect` to the enabled deploy interfaces.

This allows Ironic to select the `bootc` interface for bootc container images
while retaining `direct` as the fallback for plain OCI artifacts and standard
disk images.

## Background

BMO does not explicitly select a deploy interface for normal image deployments,
so Ironic's configured default is used. Although the `bootc` interface was
already enabled, `default_deploy_interface = direct` prevented Ironic's image
based interface detection from being reached.

The same configuration change was intentionally omitted from
openshift/ironic-image#875 while upstream autodetect regressions were being
resolved. The currently pinned Ironic revision includes the subsequent fixes
for fast-track deployments and consistent interface switching and restoration:

- https://github.com/openstack/ironic/commit/31dc1117a7e023f2ee0b731b7c2ca4d53f949708
- https://github.com/openstack/ironic/commit/3df2664ef309ec98187d9c2f8af411609ffded78

The IPA runtime dependency for bootc deployment was added separately in
openshift/ironic-agent-image#247.

## Testing

- `make check-reqs`
- `git diff --check`

Pre-merge payload validation should confirm that:

- a bootc OCI image selects the `bootc` deploy interface and boots successfully;
- a plain OCI artifact falls back to `direct`;
- existing LiveISO provisioning continues to use `ramdisk`.

## Jira

https://redhat.atlassian.net/browse/METAL-1913


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic deployment interface detection as the default option.
  * Retained support for direct deployment alongside automatic detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->